### PR TITLE
external-sourcery-toolchain: inhibit unshipped warnings

### DIFF
--- a/recipes/meta/external-sourcery-toolchain.bb
+++ b/recipes/meta/external-sourcery-toolchain.bb
@@ -107,6 +107,9 @@ INSANE_SKIP_libstdc++ += "ldflags"
 INSANE_SKIP_libgcc += "ldflags"
 INSANE_SKIP_gdbserver += "ldflags"
 
+# Suppress warnings about unshipped files and directores
+INSANE_SKIP_${PN} += "installed_vs_shipped"
+
 PKGV = "${CSL_VER_LIBC}"
 PKGV_libgcc = "${CSL_VER_GCC}"
 PKGV_libgcc-dev = "${CSL_VER_GCC}"


### PR DESCRIPTION
Hello Christopher,

please review the change, which is intended to fix SB-615 issue.

Thank you.

Best regards,
Vladimir
