### PR TITLE
external-sourcery-toolchain: kill oprofile debug bits

### DIFF
--- a/recipes/meta/external-sourcery-toolchain.bb
+++ b/recipes/meta/external-sourcery-toolchain.bb
@@ -85,7 +85,8 @@ do_install() {
 
         rm -f ${D}${bindir}/sysroot-*
 	rm -rf ${D}${datadir}/oprofile ${D}${libdir}/oprofile ${D}${datadir}/stl.pat \
-	       ${D}${mandir}/man1/oprofile* ${D}${bindir}/op* ${D}${docdir}/oprofile
+	       ${D}${mandir}/man1/oprofile* ${D}${bindir}/op* ${D}${docdir}/oprofile \
+	       ${D}${bindir}/.debug/op*
 }
 
 # These files are picked up out of the sysroot by eglibc-locale, so we don't


### PR DESCRIPTION
This is a cherry-pick from master branch.
Original commit is 1eae566b23afb057eb1cbdc82a1cfa5e21417489.

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
