### PR TITLE
lttng-tools: resurrect -O1 workaround dropped by #21

### DIFF
--- a/core/recipes-kernel/lttng/lttng-tools/compile-consumers-with-o1.patch
+++ b/core/recipes-kernel/lttng/lttng-tools/compile-consumers-with-o1.patch
@@ -1,0 +1,30 @@
+diff --git a/src/common/consumer.c b/src/common/consumer.c
+index ede214c..b10988b 100644
+--- a/src/common/consumer.c
++++ b/src/common/consumer.c
+@@ -1,3 +1,5 @@
++#pragma GCC optimize ("O1")
++
+ /*
+  * Copyright (C) 2011 - Julien Desfossez <julien.desfossez@polymtl.ca>
+  *                      Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+diff --git a/src/common/kernel-consumer/kernel-consumer.c b/src/common/kernel-consumer/kernel-consumer.c
+index d15329f..78c7725 100644
+--- a/src/common/kernel-consumer/kernel-consumer.c
++++ b/src/common/kernel-consumer/kernel-consumer.c
+@@ -1,3 +1,5 @@
++#pragma GCC optimize ("O1")
++
+ /*
+  * Copyright (C) 2011 - Julien Desfossez <julien.desfossez@polymtl.ca>
+  *                      Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+diff --git a/src/common/ust-consumer/ust-consumer.c b/src/common/ust-consumer/ust-consumer.c
+index 0955e66..0f8f75a 100644
+--- a/src/common/ust-consumer/ust-consumer.c
++++ b/src/common/ust-consumer/ust-consumer.c
+@@ -1,3 +1,5 @@
++#pragma GCC optimize ("O1")
++
+ /*
+  * Copyright (C) 2011 - Julien Desfossez <julien.desfossez@polymtl.ca>
+  *                      Mathieu Desnoyers <mathieu.desnoyers@efficios.com>

--- a/core/recipes-kernel/lttng/lttng-tools_2.4.0.bbappend
+++ b/core/recipes-kernel/lttng/lttng-tools_2.4.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI_append_arm = " file://compile-consumers-with-o1.patch"


### PR DESCRIPTION
This is needed currently, as our 2013.11 and 2014.05 IB 1 toolchains are 
affected by gcc bug 58595, which is JIRA: CB-3083.

Signed-off-by: Christopher Larson kergoth@gmail.com
