### PR TITLE
gdb: Disabled gdbserver

### DIFF
--- a/core/recipes-devtools/gdb/gdb_7.6.2.bbappend
+++ b/core/recipes-devtools/gdb/gdb_7.6.2.bbappend
@@ -1,0 +1,4 @@
+# Disable build of gdbserver because it is 
+# provided by external-sourcery-toolchain
+PACKAGES := "${@oe_filter_out('gdbserver', '${PACKAGES}', d)}"
+EXTRA_OECONF += "--disable-gdbserver"


### PR DESCRIPTION
Disable build of gdbserver because it is provided by
external-sourcery-toolchain

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
