### PR TITLE
tcmode: export MGLS and LM_LICENSE_FILE

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -14,6 +14,10 @@ NO32LIBS ?= "0"
 # sysroot and determine this accurately.
 GLIBC_GENERATE_LOCALES_remove = "en_US.UTF-8"
 
+# Ensure that the licensing variables are available to the toolchain
+export MGLS
+export LM_LICENSE_FILE
+
 # Don't ship any toolchain binaries in the sdk for the time being
 # FIXME: find a way to do this just for the recipes which include those
 # binaries. Potentially we could replace the packagegroup with an alternative


### PR DESCRIPTION
This is necessary for the toolchain licensing.

JIRA: SB-2612
