### PR TITLE
tcmode: use /tmp/sourcery-$LOGNAME for TMPDIR

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -154,17 +154,23 @@ def populate_toolchain_links(d):
     if not files:
         bb.fatal("Unable to populate toolchain binary symlinks in %s" % pattern)
 
+
+    origenv = d.getVar('BB_ORIGENV', False)
+    logname = origenv.get('LOGNAME', 'unknown')
+    tmpdir = os.path.join(origenv.get('TMPDIR', '/tmp'), 'sourcery-%s' % logname)
+    bb.utils.mkdirhier(tmpdir)
+
     bindir = d.getVar('STAGING_BINDIR_TOOLCHAIN', True)
     bb.utils.mkdirhier(bindir)
     for f in files:
         base = os.path.basename(f)
         newpath = os.path.join(bindir, base)
-        try:
-            os.symlink(f, newpath)
-        except OSError as exc:
-            if exc.errno == errno.EEXIST:
-                break
-            bb.fatal("Unable to populate toolchain binary symlink for %s: %s" % (newpath, exc))
+        if not os.path.exists(newpath):
+            with open(newpath, 'w') as new:
+                new.write('#!/bin/sh\n')
+                new.write('export TMPDIR="{0}"\n'.format(tmpdir))
+                new.write('exec "{0}" "$@"\n'.format(f))
+                os.fchmod(new.fileno(), 0755)
 
     # Ensure that we have a ld.bfd available, now that KERNEL_LD uses it
     ld = d.expand('${TARGET_PREFIX}ld')


### PR DESCRIPTION
Work around the bad interaction between cs-license and pseudo by shoving all
the temporary files into a subdir by the user's original logname.

JIRA: SB-1905

Signed-off-by: Christopher Larson kergoth@gmail.com
