### PR TITLE
tcmode: disable pseudo for gcc/g++/cpp

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -158,15 +158,24 @@ def populate_toolchain_links(d):
 
     bindir = d.getVar('STAGING_BINDIR_TOOLCHAIN', True)
     bb.utils.mkdirhier(bindir)
+    wrapped = ['gcc', 'g++', 'cpp']
     for f in files:
         base = os.path.basename(f)
         newpath = os.path.join(bindir, base)
-        try:
-            os.symlink(f, newpath)
-        except OSError as exc:
-            if exc.errno == errno.EEXIST:
-                break
-            bb.fatal("Unable to populate toolchain binary symlink for %s: %s" % (newpath, exc))
+        if not os.path.exists(newpath):
+            if any(base.endswith(w) for w in wrapped):
+                with open(newpath, 'w') as new:
+                    new.write('#!/bin/sh\n')
+                    new.write('export PSEUDO_UNLOAD=1\n')
+                    new.write('exec {0} "$@"\n'.format(f))
+                os.chmod(newpath, 0755)
+            else:
+                try:
+                    os.symlink(f, newpath)
+                except OSError as exc:
+                    if exc.errno == errno.EEXIST:
+                        break
+                    bb.fatal("Unable to populate toolchain binary symlink for %s: %s" % (newpath, exc))
 
     # Ensure that we have a ld.bfd available, now that KERNEL_LD uses it
     ld = d.expand('${TARGET_PREFIX}ld')


### PR DESCRIPTION
Revert the previous workaround for this issue and resurrect a more limited
implementation of the previous workaround.

The sourcery toolchain writes temporary files to /tmp, and includes the
username. If multiple users are doing builds with pseudo enabled, it'll try
to write to the other user's file, since both will use 'root', and the
build will fail as a result.

We don't want to wrap all the toolchain binaries, as they don't all call the
tools which write these lockfiles, and objcopy has to be excluded, as it
modifies installed binaries when the packaging process splits out the debug
info. If that operation occurs outside of pseudo's knowledge, Bad Things will
happen.

Confirmed that this fixes the problem. Also used buildhistory-diff to check for
impact on the permissions/ownership in the resulting images (tested
core-image-base and ivi-image), and compared the number of pseudo
errors/warnings in the pseudo.log files.

JIRA: MEIP-393, SB-1905
