### PR TITLE
tcmode: drop sdk toolchain removal

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -9,10 +9,6 @@ EXTERNAL_TOOLCHAIN ?= "UNDEFINED"
 # errors or warnings.
 NO32LIBS ?= "0"
 
-# We don't need or want to build a cross-compiler to ship in the sdk/ade, as
-# we expect folks to use the Sourcery G++ toolchain on the SDKMACHINE as well.
-TOOLCHAIN_HOST_TASK_remove = "packagegroup-cross-canadian-${MACHINE}"
-
 # Ensure that we only attempt to package up locales which are available in the
 # external toolchain. In the future, we should examine the external toolchain
 # sysroot and determine this accurately.


### PR DESCRIPTION
This is more a distro/user decision, I think, so move it there. Also this was
insufficient, as just removing `packagegroup-cross-canadian-${MACHINE}` without
adding back in `meta-environment-${MACHINE}` results in an sdk which hangs on
install.

See https://github.com/MentorEmbedded/meta-mentor/pull/414 for the improved
version of this in our distro layer.

Signed-off-by: Christopher Larson <kergoth@gmail.com>