### PR TITLE
external-run.inc: run in TMPDIR, not TOPDIR

### DIFF
--- a/conf/distro/include/external-run.inc
+++ b/conf/distro/include/external-run.inc
@@ -1,7 +1,7 @@
 def external_run(d, cmd, *args):
     import subprocess
 
-    topdir = d.getVar('TOPDIR', True)
+    topdir = d.getVar('TMPDIR', True)
     toolchain_path = d.getVar('EXTERNAL_TOOLCHAIN', True)
     if toolchain_path:
         target_prefix = d.getVar('EXTERNAL_TARGET_SYS', True) + '-'


### PR DESCRIPTION
TMPDIR is already in the BB_HASHBASE_WHITELIST, whereas TOPDIR is not.

Signed-off-by: Christopher Larson <kergoth@gmail.com>