### PR TITLE
Correct file ownership and add ownership QA test

### DIFF
--- a/classes/external-toolchain.bbclass
+++ b/classes/external-toolchain.bbclass
@@ -105,10 +105,12 @@ python do_install () {
 }
 
 python external_toolchain_do_install () {
+    import subprocess
     installdest = d.getVar('D', True)
     sysroots, mirrors = get_file_search_metadata(d)
     files = gather_pkg_files(d)
     copy_from_sysroots(files, sysroots, mirrors, installdest)
+    subprocess.check_call(['chown', '-R', 'root:root', installdest])
 }
 external_toolchain_do_install[vardeps] += "${@' '.join('FILES_%s' % pkg for pkg in '${PACKAGES}'.split())}"
 

--- a/classes/package_qa_sourcery.bbclass
+++ b/classes/package_qa_sourcery.bbclass
@@ -1,0 +1,36 @@
+inherit package
+
+SOURCERY_QA = "host-user-contaminated"
+
+# We need to test in fakeroot context to check file ownership
+do_package_qa[fakeroot] = "1"
+
+HOST_USER_UID := "${@os.getuid()}"
+HOST_USER_UID[type] = "integer"
+HOST_USER_GID := "${@os.getgid()}"
+HOST_USER_GID[type] = "integer"
+
+QAPATHTEST[host-user-contaminated] = "package_qa_check_host_user"
+def package_qa_check_host_user(path, name, d, elf, messages):
+    """Check for files outside of /home which are owned by the user running bitbake."""
+
+    if not os.path.lexists(path):
+        return
+
+    check_uid = oe.data.typed_value('HOST_USER_UID', d)
+    check_gid = oe.data.typed_value('HOST_USER_GID', d)
+
+    dest = d.getVar('PKGDEST', True)
+    home = os.path.join(dest, 'home')
+    if path == home or path.startswith(home + os.sep):
+        return
+
+    stat = os.lstat(path)
+    if stat.st_uid == check_uid:
+        messages["host-user-contaminated"] = "%s is owned by uid %d, which is the same as the user running bitbake. This may be due to host contamination" % (path, check_uid)
+        return False
+
+    if stat.st_gid == check_gid:
+        messages["host-user-contaminated"] = "%s is owned by gid %d, which is the same as the user running bitbake. This may be due to host contamination" % (path, check_gid)
+        return False
+    return True

--- a/core/recipes-core/ncurses/ncurses_%.bbappend
+++ b/core/recipes-core/ncurses/ncurses_%.bbappend
@@ -1,0 +1,6 @@
+# Work around the fact that gcc/g++ is not run under pseudo at the moment to
+# bypass a different bug. Ncurses links the libs directly into place in the
+# destination, so we need to correct the ownership here.
+do_install_append () {
+    chown root:root ${D}${base_libdir}/lib*.so.* ${D}${libdir}/lib*.so.*
+}


### PR DESCRIPTION
Since we're running cp -p to preserve other aspects, we need to manually
correct the ownership to what we expect (root:root) rather than the current
ownership.