### PR TITLE
glibc-external: library paths fix

### DIFF
--- a/recipes-external/glibc/glibc-external.bb
+++ b/recipes-external/glibc/glibc-external.bb
@@ -68,6 +68,10 @@ glibc_external_do_install_extra () {
                 "This may mean that your external toolchain uses a different" \
                 "multi-lib setup than your machine configuration"
     fi
+
+   sed -i -e "s# ${base_libdir}# ../..${base_libdir}#g" -e "s# ${libdir}# .#g" ${D}${libdir}/libc.so
+   sed -i -e "s# ${base_libdir}# ../..${base_libdir}#g" -e "s# ${libdir}# .#g" ${D}${libdir}/libpthread.so
+	
 }
 
 EXTERNAL_EXTRA_FILES += "\


### PR DESCRIPTION
the library paths in libpthread.so and libc.so points to system
libraries, which would not work in the ade. In the ade the relative
paths  are added so that correct libraries are linked. The fix is taken
from birch external-sourcery-toolchain recipe

recipe file at: https://github.com/MentorEmbedded/meta-
sourcery/blob/release/2014.12-async1/recipes/meta/external-sourcery-
toolchain.bb

Signed-off-by: adnan-ali1 <m_adnanali_1@hotmail.com>