### PR TITLE
Properly blacklist ${TARGET_ARCH}-suffixed recipes

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -51,10 +51,6 @@ PNBLACKLIST[uclibc-initial] = "not building with an external toolchain"
 PNBLACKLIST[glibc] = "not building with an external toolchain"
 PNBLACKLIST[glibc-initial] = "not building with an external toolchain"
 PNBLACKLIST[glibc-intermediate] = "not building with an external toolchain"
-PNBLACKLIST[binutils-cross] = "not building with an external toolchain"
-PNBLACKLIST[gcc-cross] = "not building with an external toolchain"
-PNBLACKLIST[gcc-cross-initial] = "not building with an external toolchain"
-PNBLACKLIST[gcc-cross-intermediate] = "not building with an external toolchain"
 PNBLACKLIST[gcc-runtime] = "not building with an external toolchain"
 PNBLACKLIST[gcc-sanitizers] = "not building with an external toolchain"
 PNBLACKLIST[libgcc-initial] = "not building with an external toolchain"
@@ -62,6 +58,12 @@ PNBLACKLIST[libgcc] = "not building with an external toolchain"
 PNBLACKLIST[linux-libc-headers] = "not building with an external toolchain"
 PNBLACKLIST[linux-libc-headers-yocto] = "not building with an external toolchain"
 PNBLACKLIST[external-sourcery-toolchain] = "using meta-sourcery, not poky's external toolchain"
+EXTERNAL_PNBLACKLIST_MULTILIB += "\
+    gcc-cross-${TARGET_ARCH} \
+    gcc-cross-initial-${TARGET_ARCH} \
+    binutils-cross-${TARGET_ARCH} \
+"
+EXTERNAL_PNBLACKLIST_MULTILIB[doc] = "List of recipes to blacklist whose names vary in more than just prefix between multilib variants."
 
 # Determine the prefixes to check for based on the target architecture (before
 # any classes alter TARGET_ARCH)
@@ -153,6 +155,29 @@ python toolchain_metadata_setup () {
             pass
         else:
             d.appendVar('TUNE_CCARGS', ' -msgxx-glibc')
+
+    blacklisted = d.getVar('EXTERNAL_PNBLACKLIST_MULTILIB', False)
+    for var in d.expand(blacklisted).split():
+        d.setVarFlag('PNBLACKLIST', var, 'not building with an external toolchain')
+
+    multilibs = d.getVar('MULTILIBS', True)
+    if not multilibs:
+        return
+
+    # this block has been copied from base.bbclass so keep it in sync
+    prefixes = []
+    for ext in multilibs.split():
+        eext = ext.split(':')
+        if len(eext) > 1 and eext[0] == 'multilib':
+            prefixes.append(eext[1])
+
+    for prefix in prefixes:
+        localdata = bb.data.createCopy(d)
+        override = ':virtclass-multilib-' + prefix
+        localdata.setVar('OVERRIDES', localdata.getVar('OVERRIDES', False) + override)
+        bb.data.update_data(localdata)
+        for var in localdata.expand(blacklisted).split():
+            e.data.setVarFlag('PNBLACKLIST', prefix + '-' + var, 'not building with an external toolchain')
 }
 toolchain_metadata_setup[eventmask] = "bb.event.ConfigParsed"
 addhandler toolchain_metadata_setup


### PR DESCRIPTION
This fixes issues with multilib handling.

JIRA: SB-4705

Signed-off-by: Christopher Larson <kergoth@gmail.com>