### PR TITLE
glibc: don't install a multilib suffix of '.'

### DIFF
--- a/recipes-external/glibc/glibc-sysroot-setup.inc
+++ b/recipes-external/glibc/glibc-sysroot-setup.inc
@@ -3,13 +3,17 @@ def sysroot_multilib_suffix(d):
     target_cc_arch = d.getVar('TARGET_CC_ARCH', True)
     options = d.getVar('TOOLCHAIN_OPTIONS', True) or d.expand('--sysroot=${STAGING_DIR_TARGET}')
     sysroot = external_run(d, 'gcc', *(target_cc_arch.split() + options.split() + ['-print-sysroot'])).rstrip()
+
     staging = d.getVar('STAGING_DIR_HOST', True)
-    return os.path.relpath(sysroot, staging)
+    if sysroot == staging:
+        return ''
+    else:
+        return os.path.relpath(sysroot, staging)
 
 create_multilib_link () {
 	dest="$1"
 	multilib_suffix="${@sysroot_multilib_suffix(d)}"
-	if [ "$multilib_suffix" != "." ]; then
+	if [ -n "$multilib_suffix" ]; then
 		rm -rf $dest/$multilib_suffix
 		ln -s . $dest/$multilib_suffix
 	fi


### PR DESCRIPTION
This was causing it to package the entire sysroot in certain cases.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>