### PR TITLE
external-toolchain: filter out .debug for parse time check

### DIFF
--- a/classes/external-toolchain.bbclass
+++ b/classes/external-toolchain.bbclass
@@ -92,6 +92,7 @@ python () {
     pattern = d.getVar('EXTERNAL_PROVIDE_PATTERN', True)
     if pattern is None:
         files = list(gather_pkg_files(d))
+        files = filter(lambda f: '.debug' not in f, files)
         expanded = expand_paths(files, mirrors)
         paths = search_sysroots(expanded, sysroots)
         if not any(f for p, f in paths):


### PR DESCRIPTION
This improves the error message when we can't build one of our recipes due to it being skipped, due to not finding any of its files in the external toolchain, by removing all the unnecessary .debug dirs in that context.