### PR TITLE
sourcery-tuning: fix -march=armv5e failures

### DIFF
--- a/conf/distro/include/sourcery-tuning.inc
+++ b/conf/distro/include/sourcery-tuning.inc
@@ -1,3 +1,8 @@
+# Sourcery G++'s binutils isn't patched with armv5e support
+ARMPKGSFX_THUMB_armv5 = "${@bb.utils.contains("TUNE_FEATURES", "thumb", "${ARM_THUMB_SUFFIX}", "", d)}"
+
+# Use the additional tuning flags which Sourcery G++ provides in certain
+# cases, to ensure that the correct multilibs are used. E.g. '-te500v2'.
 SOURCERY_GXX_IS_PRO = "${@'1' if os.path.exists('${EXTERNAL_TOOLCHAIN}/license') else '0'}"
 
 # Workaround for ICE of gcc-4.8.x when passing -mfloat-gprs=double


### PR DESCRIPTION
The most common failure case was qemuarm.

Upstream binutils doesn't support -march=armv5e, even though gcc does. oe-core
is carrying a patch to add it, but Sourcery G++ does not do so. Currently,
ARMPKGSFX_THUMB is used in TUNE_CCARGS, and it only includes 't' when
ARM_INSTRUCTION_SET=thumb. Bypass that check for armv5, as we need
-march=armv5te rather than -march=armv5e, but we still want -mthumb removed
when appropriate.

Fixes #86

Signed-off-by: Christopher Larson <chris_larson@mentor.com>