### PR TITLE
glibc-external: don't setup bits/syscall.h

### DIFF
--- a/recipes-external/glibc/glibc-external.bb
+++ b/recipes-external/glibc/glibc-external.bb
@@ -134,6 +134,8 @@ python () {
     # Undo the do_install_append which joined shell to python
     install = d.getVar('do_install', False)
     python, shell = install.split('rm -f ', 1)
+    # bits/syscall.h is in linux-libc-headers-external
+    shell = shell.replace('oe_multilib_header bits/syscall.h\n', '')
     d.setVar('do_install_glibc', 'rm -f ' + shell)
     d.setVarFlag('do_install_glibc', 'func', '1')
     new_install = python + '\n    bb.build.exec_func("do_install_glibc", d)\n'


### PR DESCRIPTION
We were seeing an error message about bits/syscall.h being missing. Fix by
removing the bits/syscall.h setup from the glibc-package do_install_append.
Thanks to @arehman199   for finding the root cause of this problem.