### PR TITLE
tcmode: improve CodeBench PATH removal

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -137,9 +137,8 @@ python toolchain_metadata_setup () {
     # Remove already-added toolchain install paths from the PATH, as they can
     # break the build (in particular, the ia32 toolchain, as it provdes
     # non-prefixed binaries).
-    install_prefix_default = bb.data.expand('${HOME}/CodeSourcery/', l)
     path = d.getVar('PATH', False).split(':')
-    path = filter(lambda p: not p.startswith(install_prefix_default), path)
+    path = filter(lambda p: not p.endswith('/codebench/bin'), path)
     d.setVar('PATH', ':'.join(path))
 
     # The external toolchain may not have been built with the yocto preferred


### PR DESCRIPTION
We were explicitly removing the old default install path. Rather than
explicitly removing the new install path, remove */codebench/bin/, since
that's the new structure of the installs.

JIRA: SB-5383

Signed-off-by: Christopher Larson <chris_larson@mentor.com>