### PR TITLE
glibc-external: apply Ross Burton's no-bash nscd.init patch

### DIFF
--- a/recipes-external/glibc/glibc-external/nscd.init
+++ b/recipes-external/glibc/glibc-external/nscd.init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # nscd:		Starts the Name Switch Cache Daemon
 #
@@ -49,7 +49,7 @@ prog=nscd
 start () {
     [ -d /var/run/nscd ] || mkdir /var/run/nscd
     [ -d /var/db/nscd ] || mkdir /var/db/nscd
-    echo -n $"Starting $prog: "
+    echo -n "Starting $prog: "
     daemon /usr/sbin/nscd
     RETVAL=$?
     echo
@@ -58,7 +58,7 @@ start () {
 }
 
 stop () {
-    echo -n $"Stopping $prog: "
+    echo -n "Stopping $prog: "
     /usr/sbin/nscd -K
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then
@@ -67,9 +67,9 @@ stop () {
 	# a non-privileged user
 	rm -f /var/run/nscd/nscd.pid
 	rm -f /var/run/nscd/socket
-       	success $"$prog shutdown"
+	success "$prog shutdown"
     else
-       	failure $"$prog shutdown"
+	failure "$prog shutdown"
     fi
     echo
     return $RETVAL
@@ -103,13 +103,13 @@ case "$1" in
 	RETVAL=$?
 	;;
     force-reload | reload)
-    	echo -n $"Reloading $prog: "
+	echo -n "Reloading $prog: "
 	killproc /usr/sbin/nscd -HUP
 	RETVAL=$?
 	echo
 	;;
     *)
-	echo $"Usage: $0 {start|stop|status|restart|reload|condrestart}"
+	echo "Usage: $0 {start|stop|status|restart|reload|condrestart}"
 	RETVAL=1
 	;;
 esac


### PR DESCRIPTION
This loses gettext translations support for the script, but I really doubt anyone cares in a startup script, and this aligns us with oe-core, and fixes a build warning due to the lack of bash in RDEPENDS.