### PR TITLE
Use --no-sysroot-suffix

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -41,6 +41,9 @@ PREFERRED_PROVIDER_oprofile ??= "oprofile"
 PREFERRED_PROVIDER_libgcc = "libgcc-external"
 PREFERRED_PROVIDER_linux-libc-headers = "linux-libc-headers-external"
 
+# Support use of an external toolchain with the SDK/ADE/etc
+TOOLCHAIN_HOST_TASK_append = " nativesdk-external-script"
+
 # Pull in our utility functions for use elsewhere
 INHERIT += "external-common"
 
@@ -101,7 +104,9 @@ EXTERNAL_TARGET_SYS[vardepvalue] = "${EXTERNAL_TARGET_SYS}"
 EXTERNAL_TARGET_SYS[vardepsexclude] += "EXTERNAL_TARGET_SYSTEMS EXTERNAL_TOOLCHAIN"
 TARGET_PREFIX = "${EXTERNAL_TARGET_SYS}-"
 
-TOOLCHAIN_OPTIONS = " --sysroot=${STAGING_DIR_HOST}"
+# TOOLCHAIN_OPTIONS would seem more appropriate, but that gets added to LD as
+# well, and --no-sysroot-suffix only works for gcc, not binutils.
+HOST_CC_ARCH += "--no-sysroot-suffix"
 
 CSL_IS_PRO = "${@'1' if os.path.exists('${EXTERNAL_TOOLCHAIN}/license') else '0'}"
 

--- a/recipes-external/glibc/glibc-external.bb
+++ b/recipes-external/glibc/glibc-external.bb
@@ -109,7 +109,6 @@ glibc_external_do_install_extra () {
                 "This may mean that your external toolchain uses a different" \
                 "multi-lib setup than your machine configuration"
     fi
-    create_multilib_link ${D}
     if [ "${GLIBC_INTERNAL_USE_BINARY_LOCALE}" != "precompiled" ]; then
         rm -rf ${D}${localedir}
     fi
@@ -203,7 +202,6 @@ FILES_${PN}-dev += "\
     ${libdir}/libthread_db${SOLIBSDEV} \
     ${libdir}/libpthread${SOLIBSDEV} \
 "
-FILES_${PN}-dev += "${@sysroot_multilib_suffix(d)}"
 libc_headers_file = "${@bb.utils.which('${FILESPATH}', 'libc.headers')}"
 FILES_${PN}-dev += "\
     ${@' '.join('${includedir}/' + f.rstrip() for f in base_read_file('${libc_headers_file}').splitlines())} \

--- a/recipes-external/glibc/glibc-sysroot-setup.inc
+++ b/recipes-external/glibc/glibc-sysroot-setup.inc
@@ -1,28 +1,5 @@
-def sysroot_multilib_suffix(d):
-    PATH = d.getVar('PATH', True)
-    target_cc_arch = d.getVar('TARGET_CC_ARCH', True)
-    options = d.getVar('TOOLCHAIN_OPTIONS', True) or d.expand('--sysroot=${STAGING_DIR_TARGET}')
-    sysroot = oe.external.run(d, 'gcc', *(target_cc_arch.split() + options.split() + ['-print-sysroot'])).rstrip()
-
-    staging = d.getVar('STAGING_DIR_HOST', True)
-    if sysroot == staging:
-        return ''
-    else:
-        return os.path.relpath(sysroot, staging)
-
-create_multilib_link () {
-	dest="$1"
-	multilib_suffix="${@sysroot_multilib_suffix(d)}"
-	if [ -n "$multilib_suffix" ]; then
-		rm -rf $dest/$multilib_suffix
-		ln -s . $dest/$multilib_suffix
-	fi
-}
-
 SYSROOT_PREPROCESS_FUNCS += "external_toolchain_sysroot_adjust"
 external_toolchain_sysroot_adjust() {
-	create_multilib_link ${SYSROOT_DESTDIR}
-
 	# If the usr/lib directory doesn't exist, the toolchain fails to even
 	# try to find crti.o in a completely different directory (usr/lib64)
 	install -d ${SYSROOT_DESTDIR}/usr/lib

--- a/recipes-sdk/external-script/external-script/external.sh
+++ b/recipes-sdk/external-script/external-script/external.sh
@@ -1,0 +1,4 @@
+export CC="$CC --no-sysroot-suffix"
+export CXX="$CXX --no-sysroot-suffix"
+export CPP="$CPP --no-sysroot-suffix"
+export KCFLAGS="$KCFLAGS --no-sysroot-suffix"

--- a/recipes-sdk/external-script/nativesdk-external-script.bb
+++ b/recipes-sdk/external-script/nativesdk-external-script.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Adjustments to the SDK environment for an external toolchain."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SRC_URI = "file://external.sh"
+
+inherit nativesdk
+
+do_install () {
+    install -d "${D}${SDKPATHNATIVE}/environment-setup.d"
+    install -m 0644 -o root -g root "${WORKDIR}/external.sh" "${D}${SDKPATHNATIVE}/environment-setup.d/"
+}
+
+FILES_${PN} += "${SDKPATHNATIVE}/environment-setup.d/*"


### PR DESCRIPTION
With this, we can avoid the need to create a symlink for the multilib sysroot
suffix. This also adds a nativesdk package to the sdk to adjust the
environment setup there to use it as well.

JIRA: SB-6018