### PR TITLE
tcmode: fix BASELIB for aarch64

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -9,6 +9,9 @@ EXTERNAL_TOOLCHAIN ?= "UNDEFINED"
 # errors or warnings.
 NO32LIBS ?= "0"
 
+# Align paths with the external toolchain
+BASELIB_aarch64 = "lib64"
+
 # Ensure that we only attempt to package up locales which are available in the
 # external toolchain. In the future, we should examine the external toolchain
 # sysroot and determine this accurately.


### PR DESCRIPTION
The library path in the sourcery toolchain for aarch64 is lib64, not lib.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>