### PR TITLE
tcmode: set localedir back to ${exec_prefix}/lib/locale

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -17,6 +17,9 @@ BASELIB_aarch64 = "lib64"
 # sysroot and determine this accurately.
 GLIBC_GENERATE_LOCALES_remove = "en_US.UTF-8"
 
+# Align localedir with the corresponding path in external toolchain
+localedir = "${exec_prefix}/lib/locale"
+
 # No need to re-compile the locale files
 GLIBC_INTERNAL_USE_BINARY_LOCALE ?= "precompiled"
 ENABLE_BINARY_LOCALE_GENERATION = ""


### PR DESCRIPTION
This reverts commit 4c72f28c6ecc691bcd7f04ac5fddccb2f2a6998b
to align localedir with the external toolchain

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>