### PR TITLE
libgcc-external: move libgcov.a to ${PN}-dev

### DIFF
--- a/recipes-external/gcc/libgcc-external.bb
+++ b/recipes-external/gcc/libgcc-external.bb
@@ -8,7 +8,6 @@ PV = "${GCC_VERSION}"
 inherit external-toolchain
 
 LICENSE = "GPL-3.0-with-GCC-exception"
-PACKAGES =+ "libgcov-dev"
 
 # libgcc needs libc, but glibc's utilities need libgcc, so short-circuit the
 # interdependency here by manually specifying it rather than depending on the
@@ -31,8 +30,7 @@ FILES_${PN}-dev = "${base_libdir}/libgcc_s.so \
                    ${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/libgcc.a \
                    ${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/libgcc_eh.a \
                    ${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/include/unwind.h \
+                   ${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/libgcov.a \
                    "
 INSANE_SKIP_${PN}-dev += "staticdev"
 FILES_${PN}-dbg += "${base_libdir}/.debug/libgcc_s.so.*.debug"
-FILES_libgcov-dev = "${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/libgcov.a"
-INSANE_SKIP_libgcov-dev += "staticdev"


### PR DESCRIPTION
This aligns with the non-external recipe, and as ${PN}-dev already disables
the staticdev QA check, this also silences the libgcov-dev QA warning. We
could also have changed libgcov-dev to ${MLPREFIX}libgcov-dev.

JIRA: SB-6225