### PR TITLE
libgfortran-external: kill unneeded and wrong PACKAGES

### DIFF
--- a/recipes-external/gcc/libgfortran-external.bb
+++ b/recipes-external/gcc/libgfortran-external.bb
@@ -13,12 +13,6 @@ FILES_MIRRORS =. "${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/|${external_libroot
 
 EXTERNAL_PROVIDE_PATTERN = "${FILES_${PN}}"
 
-PACKAGES = "\
-    ${PN}-dbg \
-    libgfortran \
-    libgfortran-dev \
-    libgfortran-staticdev \
-"
 FILES_${PN} = "${libdir}/libgfortran.so.*"
 FILES_${PN}-dev = "\
     ${libdir}/libgfortran*.so \


### PR DESCRIPTION
There's no need to override this, the default packages is fine, and we already
rprovides the non-external-suffixed package names. This would also have caused
breakage for multilib builds, as the specified package names in PACKAGES
didn't include MLPREFIX.