### PR TITLE
Improve external toolchain sanity checks

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -182,10 +182,13 @@ python toolchain_sanity_check () {
     if not os.path.exists(external_toolchain):
         bb.fatal("EXTERNAL_TOOLCHAIN is invalid: path '%s' does not exist" % external_toolchain)
 
-    gccpath = os.path.join(external_toolchain, 'bin', e.data.expand('${EXTERNAL_TARGET_SYS}-gcc'))
+    bindir = os.path.join(external_toolchain, 'bin')
+    if not os.path.exists(bindir):
+        bb.fatal("EXTERNAL_TOOLCHAIN is invalid: path '%s' does not exist" % bindir)
+
+    gccpath = os.path.join(bindir, e.data.expand('${EXTERNAL_TARGET_SYS}-gcc'))
     if not os.path.exists(gccpath):
-        if (os.path.exists(os.path.dirname(gccpath)) and
-            d.getVar('EXTERNAL_TARGET_SYS', True) == d.getVar('TARGET_SYS', True)):
+        if d.getVar('EXTERNAL_TARGET_SYS', True) == d.getVar('TARGET_SYS', True):
             bb.warn("EXTERNAL_TARGET_SYS == TARGET_SYS. This indicates that the prefixes specified by EXTERNAL_TARGET_SYSTEMS were not found.")
         bb.fatal("EXTERNAL_TOOLCHAIN gcc path '%s' does not exist" % gccpath)
 

--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -177,17 +177,17 @@ python toolchain_sanity_check () {
     d = e.data
     external_toolchain = d.getVar('EXTERNAL_TOOLCHAIN', True)
     if not external_toolchain or external_toolchain == 'UNDEFINED':
-        bb.fatal("Error: EXTERNAL_TOOLCHAIN must be set to the path to your sourcery toolchain")
+        bb.fatal("EXTERNAL_TOOLCHAIN must be set to the path to your sourcery toolchain")
 
     if not os.path.exists(external_toolchain):
-        bb.fatal("Error: EXTERNAL_TOOLCHAIN path '%s' does not exist" % external_toolchain)
+        bb.fatal("EXTERNAL_TOOLCHAIN is invalid: path '%s' does not exist" % external_toolchain)
 
     gccpath = os.path.join(external_toolchain, 'bin', e.data.expand('${EXTERNAL_TARGET_SYS}-gcc'))
     if not os.path.exists(gccpath):
         if (os.path.exists(os.path.dirname(gccpath)) and
             d.getVar('EXTERNAL_TARGET_SYS', True) == d.getVar('TARGET_SYS', True)):
             bb.warn("EXTERNAL_TARGET_SYS == TARGET_SYS. This indicates that the prefixes specified by EXTERNAL_TARGET_SYSTEMS were not found.")
-        bb.fatal("Error: EXTERNAL_TOOLCHAIN gcc path '%s' does not exist" % gccpath)
+        bb.fatal("EXTERNAL_TOOLCHAIN gcc path '%s' does not exist" % gccpath)
 
     if d.getVar('GCC_VERSION', True) == 'UNKNOWN':
         bb.warn("EXTERNAL_TOOLCHAIN gcc version extraction failed, see debug messages for details")


### PR DESCRIPTION
When ${EXTERNAL_TOOLCHAIN}/bin doesn't exist, it prints:

    ERROR: EXTERNAL_TOOLCHAIN is invalid: path '/scratch/cedar/toolchains/arm/bin/bin' does not exist