### PR TITLE
sourcery-tuning: remove TUNE_CCARGS set by poky tune files

### DIFF
--- a/conf/distro/include/sourcery-tuning.inc
+++ b/conf/distro/include/sourcery-tuning.inc
@@ -5,6 +5,15 @@ ARMPKGSFX_THUMB_armv5 = "${@bb.utils.contains("TUNE_FEATURES", "thumb", "${ARM_T
 # cases, to ensure that the correct multilibs are used. E.g. '-te500v2'.
 SOURCERY_GXX_IS_PRO = "${@'1' if os.path.exists('${EXTERNAL_TOOLCHAIN}/license') else '0'}"
 
+# Remove TUNE_CCARGS for e500v2, e500mc and e6500 targets set by poky tune files
+# These may be added again by the code below depending upon SOURCERY_GXX_IS_PRO
+TUNE_CCARGS_IMMEDIATE := "${TUNE_CCARGS}"
+TUNE_CCARGS_IMMEDIATE_remove = "${@bb.utils.contains("TUNE_FEATURES", "ppce500v2", "-mcpu=8548", "", d)}"
+TUNE_CCARGS_IMMEDIATE_remove = "${@bb.utils.contains("TUNE_FEATURES", [ "ppce500v2", "spe" ], "-mabi=spe -mspe -mfloat-gprs=double", "", d)}"
+TUNE_CCARGS_IMMEDIATE_remove = "${@bb.utils.contains("TUNE_FEATURES", "ppce500mc", "-mcpu=e500mc", "", d)}"
+TUNE_CCARGS_IMMEDIATE_remove = "${@bb.utils.contains("TUNE_FEATURES", "e6500", "-mcpu=e6500", '', d)}"
+TUNE_CCARGS = "${TUNE_CCARGS_IMMEDIATE}"
+
 # Workaround for ICE of gcc-4.8.x when passing -mfloat-gprs=double
 # Bug: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=57717#c1
 # Replace double-float with single-float, revert this when above bug is fixed


### PR DESCRIPTION
Remove TUNE_CCARGS for e500v2, e500mc and e6500 targets, set by poky
tune files.

Current logic of sourcery-tuning and poky tune files is such that if
SOURCERY_GXX_IS_PRO is '1' then both poky tune files and sourcery-tuning
add their own flags to TUNE_CCARGS. On the other hand same flags get
appended to TUNE_CCARGS if SOURCERY_GXX_IS_PRO is not '1'.

e.g for e6500, tune-ppce6500.inc file in poky will add "-mcpu=e6500"
and sourcery-tuning will add "-te6500" to TUNE_CCARGS given that
SOURCERY_GXX_IS_PRO is '1'. Furthermore if SOURCERY_GXX_IS_PRO is not
'1' then both sourcery-tuning and poky will append "-mcpu=e6500" to
TUNE_CCARGS.

JIRA: SB-6290

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>