### PR TITLE
sourcery-tuning: remove -mcpu flag for t4240rdb-64b

### DIFF
--- a/conf/distro/include/sourcery-tuning.inc
+++ b/conf/distro/include/sourcery-tuning.inc
@@ -17,3 +17,5 @@ TUNE_CCARGS_append = "${@bb.utils.contains('TUNE_FEATURES', 'ppce500mc', ' ' + d
 PPCE6500_CCARG = "${@'-te6500' if d.getVar('SOURCERY_GXX_IS_PRO', True) == '1' else '-mcpu=e6500'}"
 TUNE_CCARGS_append = " ${@bb.utils.contains("TUNE_FEATURES", "e6500", ' ' + d.getVar('PPCE6500_CCARG', True), '', d)}"
 TUNE_ASARGS += "${@bb.utils.contains("TUNE_FEATURES", "m64", "-a64 -me6500", "", d)}"
+
+TUNE_CCARGS_remove_t4240rdb-64b = "-mcpu=e6500"


### PR DESCRIPTION
Remove -mcpu=e6500 flag from TUNE_CCARGS for t4240rdb-64b
to match the toolchain options, in ADE's environment script,
with the CS3 data used by the IDE(Sourcery CodeBench).

IDE reads in the individual ABI and other toolchain options
from ADE's environment-setup script and attempts to map each
value to its appropriate OptionValue in the target data
plugin.xml. Many of the the values in the plugin.xml
(particularly the ABI values) originate from the CS3
information.

When the IDE finds a value in environment-setup script which
cannot be mapped to a value in plugin.xml, e.g -mcpu=e6500 in
this case, it simply appends it to the misc option field and
this behavior is known to be imperfect.

JIRA: SB-6290

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>