### PR TITLE
Fix multiple providers for cedar asyncs

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -39,7 +39,7 @@ PREFERRED_PROVIDER_virtual/libc ?= "glibc-external"
 PREFERRED_PROVIDER_virtual/libintl ?= "glibc-external"
 PREFERRED_PROVIDER_virtual/libiconv ?= "glibc-external"
 
-PREFERRED_PROVIDER_gdbserver ??= "gdbserver-external"
+PREFERRED_PROVIDER_gdbserver ??= "gdb"
 PREFERRED_PROVIDER_oprofile ??= "oprofile"
 
 # These are defined in default-providers.inc, which is parsed before the

--- a/core/recipes-devtools/gdb/gdb_%.bbappend
+++ b/core/recipes-devtools/gdb/gdb_%.bbappend
@@ -1,4 +1,4 @@
-PROVIDES += "gdbserver"
+PROVIDES += "${@'gdbserver' if '${PREFERRED_PROVIDER_gdbserver}' == '${PN}' else ''}"
 
 # Disable build of gdbserver if is provided by external-sourcery-toolchain
 PACKAGES := "${@oe_filter_out('gdbserver' if '${PREFERRED_PROVIDER_gdbserver}' != '${PN}' else '$', '${PACKAGES}', d)}"


### PR DESCRIPTION
@Noor-Ahsan this is identical to what is in the master branch.  I'm requesting this against the cedar branch since the AMD platforms need the ability to build target tools.  Per our discussion this morning I think the right approach is to merge this into the cedar branch for the async and let the locked down manifest for the formal Cedar release keep the old commit hash.  Is that right?