### PR TITLE
tcmode: also override baselib for x86-64

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -9,8 +9,11 @@ EXTERNAL_TOOLCHAIN ?= "UNDEFINED"
 # errors or warnings.
 NO32LIBS ?= "0"
 
-# Align paths with the external toolchain
-BASELIB_aarch64 = "lib64"
+# Align paths with the external toolchain, which uses the suffixed libdir path
+# for all multilibs, rather than just 'lib' for the default.
+baselib_multilib = "${@d.getVar('BASE_LIB_tune-' + (d.getVar('DEFAULTTUNE', True) or 'INVALID'), True) or d.getVar('BASELIB', True)}"
+baselib_aarch64 = "${baselib_multilib}"
+baselib_x86-64 = "${baselib_multilib}"
 
 # Ensure that we only attempt to package up locales which are available in the
 # external toolchain. In the future, we should examine the external toolchain


### PR DESCRIPTION
The Sourcery x86-64 toolchain leaves 'lib' empty and uses 'lib64' for
everything, so force that in the tcmode the way we do for aarch64.

This also switches from hardcoding BASELIB to using the bits defined in the
tuning files, to reduce how much is being hardcoded.

Thanks to @skrishnakar for finding this one. meta-sourcery fails to find libc.so
for qemux86-64 without this.