### PR TITLE
tcmode: define LDEMULATION_x86-64

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -124,6 +124,7 @@ LDEMULATION = ""
 LDEMULATION_ENDIAN = "${@'bt' if 'bigendian' in '${TUNE_FEATURES}'.split() else 'lt'}"
 LDEMULATION_BITS = "${@'64' if 'n64' in '${TUNE_FEATURES}'.split() else '32'}"
 LDEMULATION_mips64 = "elf${LDEMULATION_BITS}${LDEMULATION_ENDIAN}smip${@bb.utils.contains('TUNE_FEATURES', 'n32', 'n32', '', d)}"
+LDEMULATION_x86-64 = "elf_${TARGET_ARCH}"
 TUNE_LDARGS += "${@'-m ${LDEMULATION}' if '${LDEMULATION}' else ''}"
 
 # Ensure that the licensing variables are available to the toolchain.


### PR DESCRIPTION
Work around failure in 'perf' due to use of ld rather than gcc to link.

JIRA: SB-6527

Signed-off-by: Christopher Larson <chris_larson@mentor.com>