### PR TITLE
nativesdk-external-script: set INHIBIT_DEFAULT_DEPS

### DIFF
--- a/recipes-sdk/external-script/nativesdk-external-script.bb
+++ b/recipes-sdk/external-script/nativesdk-external-script.bb
@@ -2,6 +2,7 @@ SUMMARY = "Adjustments to the SDK environment for an external toolchain."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SRC_URI = "file://external.sh"
+INHIBIT_DEFAULT_DEPS = "1"
 
 inherit nativesdk
 


### PR DESCRIPTION
This is a script -- we don't want to suck in the toolchain. I thought about
also pulling in allarch, but I don't know how that interacts with nativesdk
yet.