### PR TITLE
Improve the error for missing gcc binary

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -95,11 +95,17 @@ EXTERNAL_TARGET_SYSTEMS = "${TARGET_SYS}"
 def external_target_sys(d):
     toolchain_path = d.getVar('EXTERNAL_TOOLCHAIN', True)
 
-    for triplet in d.getVar('EXTERNAL_TARGET_SYSTEMS', True).split():
+    systems = d.getVar('EXTERNAL_TARGET_SYSTEMS', True).split()
+    target = d.getVar('TARGET_SYS', True)
+    if target not in systems:
+        systems.append(target)
+
+    for triplet in systems:
         gcc = os.path.join(toolchain_path, 'bin', triplet + '-gcc')
         if os.path.exists(gcc):
             return triplet
-    return '${TARGET_SYS}'
+
+    return 'UNKNOWN'
 
 # We need our -cross recipes to rebuild when the external toolchain changes,
 # to recreate the links / wrapper scripts
@@ -188,11 +194,8 @@ python toolchain_sanity_check () {
     if not os.path.exists(bindir):
         bb.fatal("EXTERNAL_TOOLCHAIN is invalid: path '%s' does not exist" % bindir)
 
-    gccpath = os.path.join(bindir, e.data.expand('${EXTERNAL_TARGET_SYS}-gcc'))
-    if not os.path.exists(gccpath):
-        if d.getVar('EXTERNAL_TARGET_SYS', True) == d.getVar('TARGET_SYS', True):
-            bb.warn("EXTERNAL_TARGET_SYS == TARGET_SYS. This indicates that the prefixes specified by EXTERNAL_TARGET_SYSTEMS were not found.")
-        bb.fatal("EXTERNAL_TOOLCHAIN gcc path '%s' does not exist" % gccpath)
+    if d.getVar('EXTERNAL_TARGET_SYS', True) == 'UNKNOWN':
+        bb.fatal('Unable to locate prefixed gcc binary for %s in EXTERNAL_TOOLCHAIN/bin (%s/bin)' % (d.getVar('TARGET_SYS', True), d.getVar('EXTERNAL_TOOLCHAIN', True)))
 
     if d.getVar('GCC_VERSION', True) == 'UNKNOWN':
         bb.warn("EXTERNAL_TOOLCHAIN gcc version extraction failed, see debug messages for details")


### PR DESCRIPTION
Old messages:

    WARNING: EXTERNAL_TARGET_SYS == TARGET_SYS. This indicates that the prefixes specified by EXTERNAL_TARGET_SYSTEMS were not found.
    ERROR: EXTERNAL_TOOLCHAIN gcc path '<external-toolchain>/bin/arm-mel-linux-gnueabi-gcc' does not exist

New message:

    ERROR: Unable to locate prefixed gcc binary for arm-mel-linux-gnueabi in <external-toolchain>/bin

Signed-off-by: Christopher Larson <chris_larson@mentor.com>