### PR TITLE
tcmode-external-sourcery: Add MGLS_LICENSE_FILE if not found in envir…

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -162,9 +162,14 @@ python toolchain_metadata_setup () {
     # Determine if '-msgxx-glibc' is a valid toolchain option.
     # If so then we need to use it to ensure that the libraries included with
     # the toolchain are used rather than the build host native libraries.
+    testenv = os.environ.copy()
+    for var in ['MGLS_LICENSE_FILE', 'LM_LICENSE_FILE']:
+        if var in d:
+           testenv[var] = d.getVar(var, True)
+
     with tempfile.NamedTemporaryFile(suffix='.c') as f:
         try:
-            subprocess.check_output([d.expand('${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-gcc'), '-msgxx-glibc', '-E', f.name], cwd=d.getVar('TOPDIR', True), stderr=subprocess.STDOUT)
+            subprocess.check_output([d.expand('${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-gcc'), '-msgxx-glibc', '-E', f.name], cwd=d.getVar('TOPDIR', True), stderr=subprocess.STDOUT, env=testenv)
         except (OSError, subprocess.CalledProcessError):
             pass
         else:


### PR DESCRIPTION
…onment

Add MGLS_LICESNE_FILE and LM_LICENSE_FILE if not found in environment.

JIRA: SB-6778

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>