### PR TITLE
tcmode: use -Wl,--as-needed

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -240,3 +240,6 @@ BUILDCFG_VARS += "EXTERNAL_TOOLCHAIN SOURCERY_VERSION GCC_VERSION"
 
 # Adjust tunings to ensure we're using Sourcery G++ multilibs
 require conf/distro/include/sourcery-tuning.inc
+
+# Use -Wl,--as-needed
+require conf/distro/include/as-needed.inc


### PR DESCRIPTION
There's no reason not to make use of it, and it's used by default with the
internal toolchain, so this aligns us closer to that.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>