### PR TITLE
Updates for python 3

### DIFF
--- a/classes/external-toolchain.bbclass
+++ b/classes/external-toolchain.bbclass
@@ -29,6 +29,9 @@ PROVIDES += "${EXTERNAL_PN}"
 LICENSE = "CLOSED"
 LIC_FILES_CHKSUM = "${COMMON_LIC_CHKSUM}"
 
+# Packaging requires objcopy/etc for split and strip
+do_package[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sysroot"
+
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 

--- a/lib/oe/external.py
+++ b/lib/oe/external.py
@@ -4,8 +4,6 @@ import bb
 
 
 def run(d, cmd, *args):
-    import subprocess
-
     topdir = d.getVar('TMPDIR', True)
     toolchain_path = d.getVar('EXTERNAL_TOOLCHAIN', True)
     if toolchain_path:
@@ -14,13 +12,9 @@ def run(d, cmd, *args):
         args = [path] + list(args)
 
         try:
-            output = oe.path.check_output(args, cwd=topdir, stderr=subprocess.STDOUT)
-        except oe.path.CalledProcessError as exc:
-            import pipes
-            bb.debug(1, "{0} failed: {1}".format(' '.join(pipes.quote(a) for a in args), exc.output))
-        except OSError as exc:
-            import pipes
-            bb.debug(1, "{0} failed: {1}".format(' '.join(pipes.quote(a) for a in args), str(exc)))
+            output, _ = bb.process.run(args, cwd=topdir)
+        except bb.process.CmdError as exc:
+            bb.debug(1, str(exc))
         else:
             return output
 

--- a/recipes-external/gcc/gcc-runtime-external.bb
+++ b/recipes-external/gcc/gcc-runtime-external.bb
@@ -17,7 +17,7 @@ python () {
 }
 
 target_libdir = "${libdir}"
-HEADERS_MULTILIB_SUFFIX ?= "${@oe.external.run(d, 'gcc', *(TARGET_CC_ARCH.split() + ['-print-sysroot-headers-suffix'])).rstrip()}"
+HEADERS_MULTILIB_SUFFIX ?= "${@oe.external.run(d, 'gcc', *('${TARGET_CC_ARCH}'.split() + ['-print-sysroot-headers-suffix'])).rstrip()}"
 external_libroot = "${@os.path.realpath('${EXTERNAL_TOOLCHAIN_LIBROOT}').replace(os.path.realpath('${EXTERNAL_TOOLCHAIN}') + '/', '/')}"
 FILES_MIRRORS =. "\
     ${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/|${external_libroot}/\n \

--- a/recipes-external/gcc/gcc-runtime-external.bb
+++ b/recipes-external/gcc/gcc-runtime-external.bb
@@ -10,13 +10,10 @@ LICENSE = "GPL-3.0-with-GCC-exception & GPLv3"
 DEPENDS = "libgcc"
 EXTRA_OECONF = ""
 python () {
-    gccs = d.expand('gcc-source-${PV}')
-
-    lic_deps = d.getVarFlag('do_populate_lic', 'depends', True).split()
-    d.setVarFlag('do_populate_lic', 'depends', ' '.join(filter(lambda d: d != '{}:do_unpack'.format(gccs), lic_deps)))
-
-    cfg_deps = d.getVarFlag('do_configure', 'depends', True).split()
-    d.setVarFlag('do_configure', 'depends', ' '.join(filter(lambda d: d != '{}:do_preconfigure'.format(gccs), cfg_deps)))
+    lic_deps = d.getVarFlag('do_populate_lic', 'depends', False)
+    d.setVarFlag('do_populate_lic', 'depends', lic_deps.replace('gcc-source-${PV}:do_unpack', ''))
+    cfg_deps = d.getVarFlag('do_configure', 'depends', False)
+    d.setVarFlag('do_configure', 'depends', cfg_deps.replace('gcc-source-${PV}:do_preconfigure', ''))
 }
 
 target_libdir = "${libdir}"


### PR DESCRIPTION
oe.path.check_output was returning a bytes, not an str. Switch to bb.process
to resolve issues with python3.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>