### PR TITLE
glibc-external: don't install already installed libssp_nonshared.a

### DIFF
--- a/recipes-external/glibc/glibc-external.bb
+++ b/recipes-external/glibc/glibc-external.bb
@@ -216,3 +216,6 @@ do_package[depends] += "${MLPREFIX}libgcc:do_packagedata"
 do_package_write_ipk[depends] += "${MLPREFIX}libgcc:do_packagedata"
 do_package_write_deb[depends] += "${MLPREFIX}libgcc:do_packagedata"
 do_package_write_rpm[depends] += "${MLPREFIX}libgcc:do_packagedata"
+
+FILES_${PN}-dev_remove = "${libdir}/*_nonshared.a"
+FILES_${PN}-dev += "${libdir}/libc_nonshared.a ${libdir}/libpthread_nonshared.a"


### PR DESCRIPTION
libssp_nonshared.a is installed by gcc-runtime-external so
glibc-external should not install this into a shared area when
it already exists.

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>