### PR TITLE
tcmode: drop old triplets/prefixes

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -83,16 +83,16 @@ PNBLACKLIST_DYNAMIC += "\
 
 # Determine the prefixes to check for based on the target architecture (before
 # any classes alter TARGET_ARCH)
-EXTERNAL_TARGET_SYSTEMS[powerpc] ?= "powerpc-mentor-linux-gnu powerpc-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[powerpc64] ?= "powerpc-mentor-linux-gnu powerpc-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[arm] ?= "arm-mentor-linux-gnueabi arm-none-linux-gnueabi"
-EXTERNAL_TARGET_SYSTEMS[aarch64] ?= "aarch64-mentor-linux-gnu aarch64-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[mips] ?= "mips-mentor-linux-gnu mips-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[mipsel] ?= "mips-mentor-linux-gnu mips-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[mips64] ?= "mips-mentor-linux-gnu mips64-nlm-linux-gnu mips-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[x86_64] ?= "i686-mentor-linux-gnu x86_64-linux-gnu x86_64-amd-linux-gnu i686-pc-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[i686] ?= "i686-mentor-linux-gnu i686-pc-linux-gnu"
-EXTERNAL_TARGET_SYSTEMS[i586] ?= "i686-mentor-linux-gnu i686-pc-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[powerpc] ?= "powerpc-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[powerpc64] ?= "powerpc-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[arm] ?= "arm-none-linux-gnueabi"
+EXTERNAL_TARGET_SYSTEMS[aarch64] ?= "aarch64-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[mips] ?= "mips-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[mipsel] ?= "mips-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[mips64] ?= "mips64-nlm-linux-gnu mips-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[x86_64] ?= "x86_64-linux-gnu x86_64-amd-linux-gnu i686-pc-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[i686] ?= "i686-pc-linux-gnu"
+EXTERNAL_TARGET_SYSTEMS[i586] ?= "i686-pc-linux-gnu"
 EXTERNAL_TARGET_SYSTEMS = "${TARGET_SYS}"
 
 def external_target_sys(d):


### PR DESCRIPTION
Per @Noor-Ahsan, drop old unsupported lite toolchain triplets.

JIRA: SB-8226