### PR TITLE
Fix builds of the ppp recipe with most toolchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@
 - If it's an ia32 toolchain, make sure you did *not* let it modify your PATH,
   and if you did, remove it.
 
-  This is necessary because the ia32 Sourcery G++ toolchain
-  shipped non-prefixed binaries (e.g. `gcc` rather than `i586-none-linux-gcc`), which
+  This is necessary because the ia32 Sourcery G++ toolchain shipped
+  non-prefixed binaries (e.g. `gcc` rather than `i586-none-linux-gcc`), which
   means bitbake would be unable to run the host's gcc directly anymore.
-- Add the meta-sourcery layer to your `BBLAYERS` in `conf/bblayers.conf`. Please make
-  certain that it is listed before the `meta` layer, as this ensures meta-sourcery gets
-  priority over meta.
-- Set `EXTERNAL_TOOLCHAIN = "/path/to/your/sourcery-g++-install"` in `conf/local.conf`.
+- Add the meta-sourcery layer to your `BBLAYERS` in `conf/bblayers.conf`.
+  Please make certain that it is listed before the `meta` layer, as this
+  ensures meta-sourcery gets priority over meta.
+- Set `EXTERNAL_TOOLCHAIN = "/path/to/your/sourcery-g++-install"` in
+  `conf/local.conf`.
+- If the external toolchain was built with linux-libc-headers from the 4.8
+  Linux kernel or newer, set `KERNEL_48_PATCH_REMOVE = ""` in
+  `conf/local.conf` to fix the build of the `ppp` recipe.
 
 ### Optional Functionality
 

--- a/core/recipes-connectivity/ppp/ppp_2.4.7.bbappend
+++ b/core/recipes-connectivity/ppp/ppp_2.4.7.bbappend
@@ -1,0 +1,6 @@
+# This patch is needed, at this time, to fix builds with linux-libc-headers
+# from the 4.8 Linux kernel or newer, which is not the case for most external
+# toolchains. A separate variable is used to ensure the user can undo it from
+# local.conf if they're using a newer toolchain.
+KERNEL_48_PATCH_REMOVE ?= "file://ppp-fix-building-with-linux-4.8.patch"
+SRC_URI_remove = "${KERNEL_48_PATCH_REMOVE}"


### PR DESCRIPTION
A patch in oe-core is needed, at this time, to fix builds with
linux-libc-headers from the 4.8 Linux kernel or newer, which is not the case
for most external toolchains. Unfortunately, this patch also breaks the build
of ppp with older linux-libc-headers, so we need to revert it. A note in the
README is added explaining how to disable this for external toolchains with
recent enough kernel libc headers.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>