### PR TITLE
ppp: obey the actual libc kernel version

### DIFF
--- a/classes/external-common.bbclass
+++ b/classes/external-common.bbclass
@@ -2,6 +2,7 @@ OE_IMPORTS += "oe.external"
 
 EXTERNAL_TOOLCHAIN_SYSROOT ?= "${@oe.external.run(d, 'gcc', *(TARGET_CC_ARCH.split() + ['-print-sysroot'])).rstrip()}"
 EXTERNAL_TOOLCHAIN_LIBROOT ?= "${@oe.external.run(d, 'gcc', *(TARGET_CC_ARCH.split() + ['-print-file-name=crtbegin.o'])).rstrip().replace('/crtbegin.o', '')}"
+EXTERNAL_LIBC_KERNEL_VERSION ?= "${@external_get_kernel_version("${EXTERNAL_TOOLCHAIN_SYSROOT}${prefix}")}"
 
 EXTERNAL_INSTALL_SOURCE_PATHS = "\
     ${EXTERNAL_TOOLCHAIN_SYSROOT} \
@@ -28,3 +29,31 @@ def external_run(d, *args):
     """Convenience wrapper"""
     oe_import(d)
     return oe.external.run(d, *args)
+
+def external_get_kernel_version(p):
+    import re
+    for fn in ['include/linux/utsrelease.h', 'include/generated/utsrelease.h',
+               'include/linux/version.h']:
+        fn = os.path.join(p, fn)
+        if os.path.exists(fn):
+            break
+    else:
+        return ''
+
+    try:
+        f = open(fn)
+    except IOError:
+        pass
+    else:
+        with f:
+            lines = f.readlines()
+
+        for line in lines:
+            m = re.match(r'#define LINUX_VERSION_CODE (\d+)$', line)
+            if m:
+                code = int(m.group(1))
+                a = code >> 16
+                b = (code >> 8) & 0xFF
+                return '%d.%d' % (a, b)
+
+    return ''

--- a/core/recipes-connectivity/ppp/ppp_2.4.7.bbappend
+++ b/core/recipes-connectivity/ppp/ppp_2.4.7.bbappend
@@ -1,6 +1,8 @@
+inherit external-common
+
 # This patch is needed, at this time, to fix builds with linux-libc-headers
 # from the 4.8 Linux kernel or newer, which is not the case for most external
-# toolchains. A separate variable is used to ensure the user can undo it from
-# local.conf if they're using a newer toolchain.
-KERNEL_48_PATCH_REMOVE ?= "file://ppp-fix-building-with-linux-4.8.patch"
-SRC_URI_remove = "${KERNEL_48_PATCH_REMOVE}"
+# toolchains. As the external toolchain is available at parse time, we can
+# check the version and only apply it when appropriate.
+KERNEL_48_PATCH = "file://ppp-fix-building-with-linux-4.8.patch"
+SRC_URI_remove_class-target := "${@'${KERNEL_48_PATCH}' if [int(i) for i in ('${EXTERNAL_LIBC_KERNEL_VERSION}' or '0.0').split('.')] < [4, 8] else ''}"


### PR DESCRIPTION
Since the external toolchain is available at parse time, we can actually grab
the kernel version from the external toolchain sysroot and use that to
determine whether to apply the patch. Do so.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>