### PR TITLE
xilinx: aarch64: drop dependency on libatomic

### DIFF
--- a/xilinx-mel/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
+++ b/xilinx-mel/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
@@ -1,0 +1,5 @@
+# Remove libatomic and libatomic-dev packages as they are not available in codebench toolchain
+# for aarch64 architecture
+UNSUPPORTED_AARCH64_LIBS = "libatomic libatomic-dev"
+
+RDEPENDS_packagegroup-core-standalone-sdk-target_remove_aarch64 = "${UNSUPPORTED_AARCH64_LIBS}"


### PR DESCRIPTION
Sourcery codebench toolchain for aarch64 architecture doesn't have
libatomic available which causes ade build failure. Drop the
dependency on libatomic for aarch64 based xilinx MPSoC target.

JiraID: ITS-50

Signed-off-by: Yasir-Khan <yasir_khan@mentor.com>