### PR TITLE
oe.external: run in topdir, not tmpdir

### DIFF
--- a/lib/oe/external.py
+++ b/lib/oe/external.py
@@ -4,7 +4,7 @@ import bb
 
 
 def run(d, cmd, *args):
-    topdir = d.getVar('TMPDIR', True)
+    topdir = d.getVar('TOPDIR', True)
     toolchain_path = d.getVar('EXTERNAL_TOOLCHAIN', True)
     if toolchain_path:
         target_prefix = d.getVar('EXTERNAL_TARGET_SYS', True) + '-'


### PR DESCRIPTION
If we run in tmpdir, and run a bitbake -e after wiping tmpdir,
EXTERNAL_TOOLCHAIN_SYSROOT will be 'UNKNOWN' rather than the correct path, due
to PWD not existing when we try to extract the sysroot path.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>