### PR TITLE
perl-ptest: remove runtime dep on libssp

### DIFF
--- a/recipes-devtools/perl/perl_%.bbappend
+++ b/recipes-devtools/perl/perl_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN}-ptest_remove = "${@bb.utils.contains("MACHINE_FEATURES", "x86", "", "libssp", d)}"


### PR DESCRIPTION
libssp support is only available in toolchain for minnowmax so
remove it until there is a requirement.

Jira ID: SB-8337

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>