### PR TITLE
Drop the change of TARGET_PREFIX

### DIFF
--- a/classes/external-toolchain-cross.bbclass
+++ b/classes/external-toolchain-cross.bbclass
@@ -11,14 +11,14 @@ wrap_bin () {
     for arg in "$@"; do
         printf '%s\n' "$arg"
     done >>"$script"
-    printf 'exec ${EXTERNAL_TOOLCHAIN}/bin/${TARGET_PREFIX}%s "$@"\n' "$bin" >>"$script"
+    printf 'exec ${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-%s "$@"\n' "$bin" >>"$script"
     chmod +x "$script"
 }
 
 do_install () {
     install -d ${D}${bindir}
     for bin in ${EXTERNAL_CROSS_BINARIES}; do
-        if [ ! -e "${EXTERNAL_TOOLCHAIN}/bin/${TARGET_PREFIX}$bin" ]; then
+        if [ ! -e "${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-$bin" ]; then
             continue
         fi
 

--- a/classes/sanity-external-toolchain.bbclass
+++ b/classes/sanity-external-toolchain.bbclass
@@ -26,12 +26,12 @@ def check_toolchain_sanity(d, generate_events=False):
         raise_exttc_sanity_error('Unable to locate prefixed gcc binary for %s in EXTERNAL_TOOLCHAIN/bin (%s/bin)' % (d.getVar('TARGET_SYS', True), d.getVar('EXTERNAL_TOOLCHAIN', True)), d, generate_events)
 
     # Test 3: gcc binary exists
-    gcc = d.expand('${EXTERNAL_TOOLCHAIN}/bin/${TARGET_PREFIX}gcc')
+    gcc = d.expand('${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-gcc')
     if not os.path.exists(gcc):
         raise_exttc_sanity_error('Compiler path `%s` does not exist' % gcc, d, generate_events)
 
     # Test 4: we can run it to get the version
-    cmd = d.expand('${EXTERNAL_TOOLCHAIN}/bin/${TARGET_PREFIX}gcc -dumpversion')
+    cmd = d.expand('${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-gcc -dumpversion')
     sourcery_version = exttc_sanity_run(shlex.split(cmd), d, generate_events)
     if cfgdata.get('sourcery_version') == sourcery_version:
         return
@@ -46,6 +46,7 @@ def check_toolchain_sanity(d, generate_events=False):
         # the external toolchain sysroots for this test
         l = d.createCopy()
         l.setVar('TOOLCHAIN_OPTIONS', '')
+        l.setVar('TARGET_PREFIX', '${EXTERNAL_TARGET_SYS}-')
         l.setVar('HOST_CC_ARCH_remove', '--no-sysroot-suffix')
         cmd = l.expand('${EXTERNAL_TOOLCHAIN}/bin/${CC} ${CFLAGS} ${LDFLAGS} test.c -o test')
         exttc_sanity_run(shlex.split(cmd), d, generate_events, tmpdir)

--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -124,7 +124,6 @@ BB_HASHBASE_WHITELIST_remove = "EXTERNAL_TOOLCHAIN"
 EXTERNAL_TARGET_SYS ?= "${@external_target_sys(d)}"
 EXTERNAL_TARGET_SYS[vardepvalue] = "${EXTERNAL_TARGET_SYS}"
 EXTERNAL_TARGET_SYS[vardepsexclude] += "EXTERNAL_TARGET_SYSTEMS EXTERNAL_TOOLCHAIN"
-TARGET_PREFIX = "${EXTERNAL_TARGET_SYS}-"
 
 # TOOLCHAIN_OPTIONS would seem more appropriate, but that gets added to LD as
 # well, and --no-sysroot-suffix only works for gcc, not binutils.
@@ -183,7 +182,7 @@ python toolchain_metadata_setup () {
 
     with tempfile.NamedTemporaryFile(suffix='.c') as f:
         try:
-            subprocess.check_output([d.expand('${EXTERNAL_TOOLCHAIN}/bin/${TARGET_PREFIX}gcc'), '-msgxx-glibc', '-E', f.name], stderr=subprocess.STDOUT, env=testenv, cwd=d.getVar('TOPDIR', True))
+            subprocess.check_output([d.expand('${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-gcc'), '-msgxx-glibc', '-E', f.name], stderr=subprocess.STDOUT, env=testenv, cwd=d.getVar('TOPDIR', True))
         except (OSError, subprocess.CalledProcessError):
             pass
         else:


### PR DESCRIPTION
Since the external-cross recipes link/wrap the binaries already, there's no
actual need to override TARGET_PREFIX anymore.