### PR TITLE
sanity-external-toolchain: fix variable name

### DIFF
--- a/classes/sanity-external-toolchain.bbclass
+++ b/classes/sanity-external-toolchain.bbclass
@@ -11,7 +11,7 @@ def check_toolchain_sanity(d, generate_events=False):
 
     # Test 1: EXTERNAL_TOOLCHAIN exists
     if not os.path.exists(extpath):
-        raise_exttc_sanity_error('EXTERNAL_TOOLCHAIN path `%s` does not exist' % extdir, d, generate_events)
+        raise_exttc_sanity_error('EXTERNAL_TOOLCHAIN path `%s` does not exist' % extpath, d, generate_events)
     extpath = os.path.realpath(extpath)
 
     sanity_file = d.expand('${TOPDIR}/conf/exttc_sanity_info')


### PR DESCRIPTION
If the EXTERNAL_TOOLCHAIN path doesn't exist, the error logic had a variable
name issue (extdir vs extpath). Fix.