### PR TITLE
Correctly include existing debug files from the toolchain

### DIFF
--- a/classes/external-toolchain.bbclass
+++ b/classes/external-toolchain.bbclass
@@ -117,6 +117,7 @@ python () {
 
 # Debug files are likely already split out
 INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 
 # Toolchain shipped binaries weren't necessarily built ideally
 WARN_QA_remove = "ldflags textrel"

--- a/classes/external-toolchain.bbclass
+++ b/classes/external-toolchain.bbclass
@@ -137,6 +137,29 @@ FILES_${PN}-staticdev = ""
 FILES_${PN}-doc = ""
 FILES_${PN}-locale = ""
 
+def debug_paths(d):
+    l = d.createCopy()
+    l.finalize()
+    paths = []
+    exclude = [
+        l.getVar('datadir', True),
+        l.getVar('includedir', True),
+    ]
+    for p in l.getVar('PACKAGES', True).split():
+        if p.endswith('-dbg'):
+            continue
+        for f in (l.getVar('FILES_%s' % p, True) or '').split():
+            if any((f == x or f.startswith(x + '/')) for x in exclude):
+                continue
+            d = os.path.dirname(f)
+            b = os.path.basename(f)
+            paths.append('/usr/lib/debug{0}/{1}.debug'.format(d, b))
+            paths.append('{0}/.debug/{1}'.format(d, b))
+            paths.append('{0}/.debug/{1}.debug'.format(d, b))
+    return set(paths)
+
+FILES_${PN}-dbg = "${@' '.join(debug_paths(d))}"
+
 # do_package[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
 # do_package_write_ipk[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
 # do_package_write_deb[depends] += "virtual/${MLPREFIX}libc:do_packagedata"

--- a/recipes-external/gcc/gcc-runtime-external.bb
+++ b/recipes-external/gcc/gcc-runtime-external.bb
@@ -45,6 +45,7 @@ do_install_extra () {
     done
 }
 
+FILES_${PN}-dbg += "${datadir}/gdb/python/libstdcxx"
 FILES_libstdc++-dev = "\
     ${includedir}/c++ \
     ${libdir}/libstdc++.so \

--- a/recipes-external/gcc/libgcc-external.bb
+++ b/recipes-external/gcc/libgcc-external.bb
@@ -33,3 +33,4 @@ FILES_${PN}-dev = "${base_libdir}/libgcc_s.so \
                    ${libdir}/gcc/${TARGET_SYS}/${GCC_VERSION}/libgcov.a \
                    "
 INSANE_SKIP_${PN}-dev += "staticdev"
+FILES_${PN}-dbg += "${base_libdir}/.debug/libgcc_s.so.*.debug"


### PR DESCRIPTION
- Disable the debug split
- Gather up the .debug files corresponding to the FILES

JIRA: SB-8524