### PR TITLE
sourcery-tuning.inc: make assembler flags e6500-64b specific

### DIFF
--- a/conf/distro/include/sourcery-tuning.inc
+++ b/conf/distro/include/sourcery-tuning.inc
@@ -16,6 +16,6 @@ TUNE_CCARGS_append = "${@bb.utils.contains('TUNE_FEATURES', 'ppce500mc', ' ' + d
 
 PPCE6500_CCARG = "${@'-te6500' if d.getVar('SOURCERY_GXX_IS_PRO', True) == '1' else '-mcpu=e6500'}"
 TUNE_CCARGS_append = " ${@bb.utils.contains("TUNE_FEATURES", "e6500", ' ' + d.getVar('PPCE6500_CCARG', True), '', d)}"
-TUNE_ASARGS += "${@bb.utils.contains("TUNE_FEATURES", "m64", "-a64 -me6500", "", d)}"
+TUNE_ASARGS_e6500-64b += "${@bb.utils.contains("TUNE_FEATURES", "m64", "-a64 -me6500", "", d)}"
 
 TUNE_CCARGS_remove_t4240rdb-64b = "-mcpu=e6500"


### PR DESCRIPTION
-a64 and -me6500 are PowerPC architecture-specific assembler flags
only intended for 64bit mode of e6500 core.
-a64 - generates ELF64 or XCOFF64.
-me6500 - generates code for Freescale e6500 core complex.

Jira ID: http://jira.alm.mentorg.com:8080/browse/SIEJIR-3452

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>