### PR TITLE
tcmode-rebuild-libc: fix locales dependency error

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery-rebuild-libc.inc
+++ b/conf/distro/include/tcmode-external-sourcery-rebuild-libc.inc
@@ -8,3 +8,6 @@ PREFERRED_PROVIDER_virtual/${TARGET_PREFIX}libc-for-gcc = "glibc-sourcery"
 PREFERRED_PROVIDER_glibc = "glibc-sourcery"
 SOURCERY_SRC_URI ?= "file://${SOURCERY_SRC_FILE}"
 SOURCERY_SRC_FILE ?= "${@bb.fatal('Please set SOURCERY_SRC_FILE to the path to your sourcery src tarball')}"
+
+GLIBC_INTERNAL_USE_BINARY_LOCALE = ""
+ENABLE_BINARY_LOCALE_GENERATION = "1"


### PR DESCRIPTION
unset GLIBC_INTERNAL_USE_BINARY_LOCALE & enable
ENABLE_BINARY_LOCALE_GENERATION, in case of re-building glibc we do not have
pre-compiled locales support, so we need to compile it using these settings.

unset LOCALE_UTF8_IS_DEFAULT, also during rebuilding glibc we are getting
only non-UTF-8 encoding locales, so unset the default settings of UTF-8
encoding.

these settings required to resolve the locales dependency error while using
the re-build of glibc from sources.

JIRA: SB-8703

Signed-off-by: Shrikant Bobade <shrikant_bobade@mentor.com>