### PR TITLE
gcc-runtime-external: fix COMPILERDEP parse error

### DIFF
--- a/recipes-external/gcc/gcc-runtime-external.bb
+++ b/recipes-external/gcc/gcc-runtime-external.bb
@@ -8,6 +8,8 @@ inherit external-toolchain
 # GCC >4.2 is GPLv3
 DEPENDS = "libgcc"
 EXTRA_OECONF = ""
+COMPILERDEP = ""
+
 python () {
     lic_deps = d.getVarFlag('do_populate_lic', 'depends', False)
     d.setVarFlag('do_populate_lic', 'depends', lic_deps.replace('gcc-source-${PV}:do_unpack', ''))


### PR DESCRIPTION
We don't need or want this dep, so set it to the empty string rather than
including gcc-common.inc. This fixes builds with current upstream master.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>