### PR TITLE
systemd-boot: fix build issue on x86_64

### DIFF
--- a/recipes-bsp/systemd-boot/systemd-boot_232.bbappend
+++ b/recipes-bsp/systemd-boot/systemd-boot_232.bbappend
@@ -1,0 +1,7 @@
+# Ensure -m32/-m64 are passed for EFI, as the buildsystem currently relies on
+# the default for the toolchain, which isn't necessarily correct for an
+# external toolchain.
+EFI_TUNE_ARCH = "-m32"
+EFI_TUNE_ARCH_x86-64 = "-m64"
+EFI_CC = "${@'${CC}'.split()[0]} ${EFI_TUNE_ARCH}"
+EXTRA_OECONF += "'EFI_CC=${EFI_CC}'"


### PR DESCRIPTION
Ensure -m32/-m64 are passed for EFI, as the buildsystem currently relies on
the default for the toolchain, which isn't necessarily correct for an external
toolchain.