### PR TITLE
glibc-sourcery: Avoid dependency of bash

### DIFF
--- a/recipes-external/glibc/glibc-sourcery.bbappend
+++ b/recipes-external/glibc/glibc-sourcery.bbappend
@@ -1,0 +1,9 @@
+# Avoid bash dependency via bbappend because the glibc-sourcery recipe from
+# the Updates-2 layer is being used and that layer is locked now.
+
+do_install_append () {
+    # Avoid bash dependency
+    sed -e '1s#bash#sh#; s#$"#"#g' -i "${D}${bindir}/ldd"
+    sed -e '1s#bash#sh#' -i "${D}${bindir}/tzselect"
+    sed -e '1s#bash#sh#' -i "${D}/etc/init.d/nscd"
+}


### PR DESCRIPTION
Add bbappend file parallel to the recipe file because the glibc-sourcery
recipe from updates layer is being used and that layer is locked right now.

It fixes the following QA warning;

WARNING: glibc-sourcery-2.24-2016.11-66-r0 do_package_qa: QA Issue:
/etc/init.d/nscd contained in package nscd requires /bin/bash, but no
providers found in RDEPENDS_nscd? [file-rdeps]

Jira: http://jira.alm.mentorg.com:8080/browse/SB-9978

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>