### PR TITLE
glibc-{external,sourcery}: silence all oe_multilib_header errors

### DIFF
--- a/recipes-external/glibc/glibc-external.bbappend
+++ b/recipes-external/glibc/glibc-external.bbappend
@@ -1,11 +1,3 @@
 DEPENDS += "linux-libc-headers"
 
 FILES_${PN}-dev_remove = "${@' '.join('${includedir}/%s' % d for d in '${linux_include_subdirs}'.split())}"
-
-python () {
-    # bits/syscall.h is in linux-libc-headers-external
-    install = d.getVar('do_install_glibc', False)
-    install = install.replace('oe_multilib_header bits/syscall.h bits/long-double.h\n', '')
-    d.setVar('do_install_glibc', install)
-    
-}

--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -1,7 +1,6 @@
 require recipes-core/glibc/glibc.inc
 require recipes-external/glibc/glibc-external-version.inc
 
-
 EXTERNAL_TOOLCHAIN_SYSROOT ?= "${@oe.external.run(d, 'gcc', *(TARGET_CC_ARCH.split() + ['-print-sysroot'])).rstrip()}"
 
 LICENSE = "CLOSED"
@@ -99,6 +98,13 @@ do_install_append () {
     for dir in ${linux_include_subdirs}; do
         rm -rf "${D}${includedir}/$dir"
     done
+}
+
+bberror_task-install () {
+    # Silence any errors from oe_multilib_header, as we don't care about
+    # missing multilib headers, as the oe-core glibc version isn't necessarily
+    # the same as our own.
+    :
 }
 
 require recipes-external/glibc/glibc-sysroot-setup.inc


### PR DESCRIPTION
Silence any errors from oe_multilib_header, as we don't care about missing
multilib headers, as the oe-core glibc version isn't necessarily the same as
our own.