### PR TITLE
glibc-sourcery: use oe.utils.str_filter_out, not oe_filter_out

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -58,7 +58,7 @@ SRC_URI = "git://sourceware.org/git/glibc.git;branch=release/2.24/master;name=gl
           file://generate-supported.mk \
           "
 
-TUNE_CCARGS_mips := "${@oe_filter_out('-march=mips32', '${TUNE_CCARGS}', d)}"
+TUNE_CCARGS_mips := "${@oe.utils.str_filter_out('-march=mips32', '${TUNE_CCARGS}', d)}"
 CPPFLAGS[unexport] = "1"
 LDFLAGS[unexport] = "1"
 BUILD_CPPFLAGS = "-I${STAGING_INCDIR_NATIVE}"


### PR DESCRIPTION
oe_filter_out no longer exists upstream, and was deprecated for some time.