### PR TITLE
Move the nopseudo handling from meta-external-toolchain

### DIFF
--- a/classes/external-nopseudo.bbclass
+++ b/classes/external-nopseudo.bbclass
@@ -1,0 +1,26 @@
+EXTERNAL_CROSS_NOPSEUDO ?= ""
+
+do_install_tcmode-external-sourcery () {
+    # Identical to do_install in external-toolchain-cross.bbclass, altered to
+    # support EXTERNAL_CROSS_NOPSEUDO
+    install -d ${D}${bindir}
+    for bin in ${EXTERNAL_CROSS_BINARIES}; do
+        if [ ! -e "${EXTERNAL_TOOLCHAIN}/bin/${EXTERNAL_TARGET_SYS}-$bin" ]; then
+            continue
+        fi
+
+        disable=0
+        for nopseudo in ${EXTERNAL_CROSS_NOPSEUDO}; do
+            case "$bin" in
+                *$nopseudo)
+                    disable=1
+                    ;;
+            esac
+        done
+        if [ $disable -eq 1 ]; then
+            wrap_bin "$bin" "export PSEUDO_UNLOAD=1"
+        else
+            wrap_bin "$bin"
+        fi
+    done
+}

--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -14,6 +14,9 @@ PNBLACKLIST[linux-libc-headers-yocto] = "not building with an external toolchain
 CODEBENCH_PATH ?= ""
 CODEBENCH_TOOLCHAINS_PATH ?= "${CODEBENCH_PATH}/../toolchains"
 
+# Disable pseudo for these cross binaries
+EXTERNAL_CROSS_NOPSEUDO = "gcc g++ cpp"
+
 # Determine the prefixes to check for based on the target architecture (before
 # any classes alter TARGET_ARCH)
 EXTERNAL_TARGET_SYSTEMS[powerpc] ?= "powerpc-linux-gnu"

--- a/recipes-external/gcc/gcc-external-cross.bbappend
+++ b/recipes-external/gcc/gcc-external-cross.bbappend
@@ -1,0 +1,1 @@
+inherit external-nopseudo


### PR DESCRIPTION
These bits are a workaround which is Sourcery G++ specific.