### PR TITLE
glibc-sourcery: drop nsl/rpc bits

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -98,6 +98,7 @@ do_install_append () {
     for dir in ${linux_include_subdirs}; do
         rm -rf "${D}${includedir}/$dir"
     done
+    rm -rf "${D}${libdir}/libnsl"* "${D}${includedir}/rpcsvc"
 }
 
 bberror_task-install () {


### PR DESCRIPTION
These were obsolete bits removed from the glibc recipe in oe-core, and
are provided by other recipes.