### PR TITLE
glibc-sourcery: silence unpackaged /usr/lib warning

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -134,13 +134,8 @@ do_configure () {
     CPPFLAGS="" oe_runconf
 }
 
-linux_include_subdirs = "asm asm-generic bits drm linux mtd rdma sound sys video"
-
-do_install_append () {
-    for dir in ${linux_include_subdirs}; do
-        rm -rf "${D}${includedir}/$dir"
-    done
-}
+require recipes-external/glibc/glibc-sysroot-setup.inc
+require recipes-external/glibc/glibc-package-adjusted.inc
 
 bberror_task-install () {
     # Silence any errors from oe_multilib_header, as we don't care about
@@ -149,8 +144,16 @@ bberror_task-install () {
     :
 }
 
-require recipes-external/glibc/glibc-sysroot-setup.inc
-require recipes-external/glibc/glibc-package-adjusted.inc
+linux_include_subdirs = "asm asm-generic bits drm linux mtd rdma sound sys video"
+
+do_install_append () {
+    for dir in ${linux_include_subdirs}; do
+        rm -rf "${D}${includedir}/$dir"
+    done
+    if [ "${baselib}" != "lib" ]; then
+        rmdir --ignore-fail-on-non-empty "${D}${prefix}/lib/locale" "${D}${prefix}/lib"
+    fi
+}
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build-${TARGET_SYS}"


### PR DESCRIPTION
We can remove it in do_install rather than do_package, the reason it was
failing before is it contained an empty locale subdir from the locale
processing. If we remove that as well, it works.

JIRA: SB-11811