### PR TITLE
glibc-sourcery: move /usr/lib cleanup to post_stash_cleanup

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -150,8 +150,14 @@ do_install_append () {
     for dir in ${linux_include_subdirs}; do
         rm -rf "${D}${includedir}/$dir"
     done
+}
+
+# This should be dropped once it starts failing
+# a patch has been submitted upstream already to
+# the master branch for coping up with this.
+do_poststash_install_cleanup_append () {
     if [ "${baselib}" != "lib" ]; then
-        rmdir --ignore-fail-on-non-empty "${D}${prefix}/lib/locale" "${D}${prefix}/lib"
+        rmdir --ignore-fail-on-non-empty "${D}${prefix}/lib"
     fi
 }
 


### PR DESCRIPTION
After the stash step the cleanups are done in post_stash_cleanup
so it is more appropriate to append the corresponding function.
Additionally a patch has been submitted upstream to fix the
actual bug in libc-common.
https://patchwork.openembedded.org/patch/154968/
So once this starts failing here we should drop the function
append.

Signed-off-by: Awais Belal <awais_belal@mentor.com>