### PR TITLE
glibc-sourcery: drop unnecessary bash rdep

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -164,8 +164,6 @@ do_poststash_install_cleanup_append () {
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build-${TARGET_SYS}"
 
-RDEPENDS_tzcode += "bash"
-
 python () {
     if not d.getVar("EXTERNAL_TOOLCHAIN", True):
         raise bb.parse.SkipPackage("External toolchain not configured (EXTERNAL_TOOLCHAIN not set).")


### PR DESCRIPTION
We already remove the bash shebang from the scripts that had unnecessary
usage of bash, so this isn't needed.