### PR TITLE
glibc: fix warnings about libssp for builds with security flags

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -168,3 +168,6 @@ python () {
     if not d.getVar("EXTERNAL_TOOLCHAIN", True):
         raise bb.parse.SkipPackage("External toolchain not configured (EXTERNAL_TOOLCHAIN not set).")
 }
+
+# glibc may need libssp for -fstack-protector builds
+do_packagedata[depends] += "gcc-runtime:do_packagedata"


### PR DESCRIPTION
This requires the corresponding workaround in meta-external-toolchain to
avoid a recursion with gcc-runtime.

JIRA: SB-12465