### PR TITLE
linux-libc-headers-external: skip multilib header processing

### DIFF
--- a/recipes-external/linux-libc-headers/linux-libc-headers-external.bb
+++ b/recipes-external/linux-libc-headers/linux-libc-headers-external.bb
@@ -12,18 +12,13 @@ FILES_${PN}-dev = "${@' '.join('${includedir}/%s' % d for d in '${linux_include_
 
 BBCLASSEXTEND = ""
 
-inherit multilib_header
-
-do_install_extra () {
-    oe_multilib_header bits/syscall.h
-    if [ -e "${D}${includedir}/bits/long-double.h" ]; then
-        oe_multilib_header bits/long-double.h
-    fi
-}
-
 bberror_task-install () {
     # Silence any errors from oe_multilib_header, as we don't care about
     # missing multilib headers, as the oe-core glibc version isn't necessarily
     # the same as our own.
+    :
+}
+
+do_install_armmultilib () {
     :
 }


### PR DESCRIPTION
Signed-off-by: Christopher Larson <chris_larson@mentor.com>
