### PR TITLE
Fix rebuild libc

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery-rebuild-libc.inc
+++ b/conf/distro/include/tcmode-external-sourcery-rebuild-libc.inc
@@ -1,9 +1,12 @@
 require conf/distro/include/tcmode-external-sourcery.inc
 
-PREFERRED_PROVIDER_virtual/libc = "glibc"
-PREFERRED_PROVIDER_virtual/libiconv = "glibc"
-PREFERRED_PROVIDER_virtual/libintl = "glibc"
+TCMODEOVERRIDES .= ":tcmode-external-sourcery-rebuild-libc"
+
+PNBLACKLIST[glibc] = ""
 PREFERRED_PROVIDER_glibc = "glibc"
+PREFERRED_PROVIDER_virtual/libc = "glibc"
+PREFERRED_PROVIDER_virtual/libintl = "glibc"
+PREFERRED_PROVIDER_virtual/libiconv = "glibc"
 GLIBC_INTERNAL_USE_BINARY_LOCALE = "compile"
 ENABLE_BINARY_LOCALE_GENERATION = "1"
 LOCALE_UTF8_IS_DEFAULT_mel = "0"

--- a/recipes-core/glibc/glibc_%.bbappend
+++ b/recipes-core/glibc/glibc_%.bbappend
@@ -1,0 +1,10 @@
+# Remove files provided by linux-libc-headers
+linux_include_subdirs = "asm asm-generic bits drm linux mtd rdma sound sys video"
+
+do_install_append_tcmode-external-sourcery () {
+    for d in ${linux_include_subdirs}; do
+        rm -rf "${D}${includedir}/$d"
+    done
+}
+
+RDEPENDS_${PN}-dev_append_tcmode-external-sourcery = " linux-libc-headers-dev"


### PR DESCRIPTION
- glibc: also kill linux libc headers here for rebuild-libc
- tcmode: fix external-sourcery-rebuild-libc
