### PR TITLE
tcmode: fix exception when SETUP_SCRIPT var is set

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -23,7 +23,7 @@ python extract_env_setup_metadata() {
         setup = d.getVar('EXTERNAL_TOOLCHAIN_SETUP_SCRIPT')
         if setup:
             setup = pathlib.Path(setup)
-            env = parse_setup_script(setups[0])
+            env = parse_setup_script(setup)
         else:
             candidates = select_appropriate_setup_script(d, external_toolchain)
             if not candidates:


### PR DESCRIPTION
Signed-off-by: Christopher Larson <chris_larson@mentor.com>
