### PR TITLE
tcmode-external-sourcery-rebuild-libc: remove unneeded and incorrect …

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery-rebuild-libc.inc
+++ b/conf/distro/include/tcmode-external-sourcery-rebuild-libc.inc
@@ -7,8 +7,3 @@ PREFERRED_PROVIDER_glibc = "glibc"
 PREFERRED_PROVIDER_virtual/libc = "glibc"
 PREFERRED_PROVIDER_virtual/libintl = "glibc"
 PREFERRED_PROVIDER_virtual/libiconv = "glibc"
-GLIBC_INTERNAL_USE_BINARY_LOCALE = "compile"
-ENABLE_BINARY_LOCALE_GENERATION = "1"
-LOCALE_UTF8_IS_DEFAULT_mel = "0"
-
-PNBLACKLIST[glibc] = ""


### PR DESCRIPTION
…LOCALE_UTF8_IS_DEFAULT

JIRA: SB-15607

Signed-off-by: Christopher Larson <chris_larson@mentor.com>