### PR TITLE
sdk-env-external-toolchain: correct sys

### DIFF
--- a/external-toolchain/recipes-sdk/sdk-env-external-toolchain/sdk-env-external-toolchain.bbappend
+++ b/external-toolchain/recipes-sdk/sdk-env-external-toolchain/sdk-env-external-toolchain.bbappend
@@ -1,8 +1,10 @@
+EXTERNAL_TARGET_SYS ?= "${TARGET_ARCH}-oe-${TARGET_OS}"
+
 do_install_append_tcmode-external-sourcery () {
     install -d "${D}/environment-setup.d"
     cat >"${D}/environment-setup.d/external-codebench-toolchains.sh" <<END
 sourceryver="${SOURCERY_VERSION}"
-sys="${TUNE_PKGARCH}-oe-${TARGET_OS}"
+sys="${EXTERNAL_TARGET_SYS}"
 sysroot="${SDK_ARCH}-oesdk-${SDK_OS}"
 toolchainsdir="${SDKPATH}/../../../toolchains"
 bindir="\$toolchainsdir/\$sys.\${sourceryver%-*}/sysroots/\$sysroot/usr/bin/\$sys"


### PR DESCRIPTION
This was looking in the TUNE_PKGARCH path, but needed to look in the TARGET_ARCH path.

JIRA: SB-15747

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
