### PR TITLE
Fix warnings about libssp for builds with security flags

### DIFF
--- a/recipes-external/gcc/gcc-runtime-external.bbappend
+++ b/recipes-external/gcc/gcc-runtime-external.bbappend
@@ -1,0 +1,20 @@
+python () {
+    depends = d.getVarFlag('do_package', 'depends', False)
+    depends = depends.replace('virtual/${MLPREFIX}libc:do_packagedata', '')
+    d.setVarFlag('do_package', 'depends', depends)
+}
+
+# gcc-runtime needs libc, but glibc's utilities need libssp in some cases, so
+# short-circuit the interdependency here by manually specifying it rather than
+# depending on the libc packagedata.
+libc_rdep = "${@'${PREFERRED_PROVIDER_virtual/libc}' if '${PREFERRED_PROVIDER_virtual/libc}' else '${TCLIBC}'}"
+RDEPENDS_libgomp += "${libc_rdep}"
+RDEPENDS_libssp += "${libc_rdep}"
+RDEPENDS_libstdc++ += "${libc_rdep}"
+RDEPENDS_libatomic += "${libc_rdep}"
+RDEPENDS_libquadmath += "${libc_rdep}"
+RDEPENDS_libmpx += "${libc_rdep}"
+
+do_package_write_ipk[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_deb[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_rpm[depends] += "virtual/${MLPREFIX}libc:do_packagedata"

--- a/recipes-external/glibc/glibc-external.bbappend
+++ b/recipes-external/glibc/glibc-external.bbappend
@@ -1,3 +1,5 @@
 DEPENDS_append_tcmode-external-sourcery = " linux-libc-headers"
-
 FILES_${PN}-dev_remove_tcmode-external-sourcery = "${@' '.join('${includedir}/%s' % d for d in '${linux_include_subdirs}'.split())}"
+
+# glibc may need libssp for -fstack-protector builds
+do_packagedata[depends] += "gcc-runtime:do_packagedata"

--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -168,3 +168,6 @@ python () {
     if not d.getVar("EXTERNAL_TOOLCHAIN", True):
         raise bb.parse.SkipPackage("External toolchain not configured (EXTERNAL_TOOLCHAIN not set).")
 }
+
+# glibc may need libssp for -fstack-protector builds
+do_packagedata[depends] += "gcc-runtime:do_packagedata"

--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -169,5 +169,11 @@ python () {
         raise bb.parse.SkipPackage("External toolchain not configured (EXTERNAL_TOOLCHAIN not set).")
 }
 
+# glibc's utils need libgcc
+do_package[depends] += "${MLPREFIX}libgcc:do_packagedata"
+do_package_write_ipk[depends] += "${MLPREFIX}libgcc:do_packagedata"
+do_package_write_deb[depends] += "${MLPREFIX}libgcc:do_packagedata"
+do_package_write_rpm[depends] += "${MLPREFIX}libgcc:do_packagedata"
+
 # glibc may need libssp for -fstack-protector builds
 do_packagedata[depends] += "gcc-runtime:do_packagedata"


### PR DESCRIPTION
CUSTOMER ISSUE ID: TBD
MGC ISSUE ID: OPP-713, SB-15901, ADIT-75
SUMMARY: Setup a full ADIT build tree with rebuilding glibc based on CB 11
DESCRIPTION: Setup a full ADIT build tree with rebuilding glibc based on CB 11
RESOLUTION: Backport upstream fixes.
DEPENDENCIES: https://stash.alm.mentorg.com/projects/ADITGEN4/repos/adit-gen4-manifests/pull-requests/30/overview (adds branch cos10-adit to the manifest)
LICENSE: MIT
TEST SUMMARY: Build test with TCMODE = "external-sourcery" (current COS default) and with TCMODE = "external-sourcery-rebuild-libc" (we will use it for CVE fixes in glibc) in local.conf.
KNOWN LIMITATIONS: None
SOURCES: None