### PR TITLE
sdk-env-external-toolchain: correct escaping for dirsuffix

### DIFF
--- a/external-toolchain/recipes-sdk/sdk-env-external-toolchain/sdk-env-external-toolchain.bbappend
+++ b/external-toolchain/recipes-sdk/sdk-env-external-toolchain/sdk-env-external-toolchain.bbappend
@@ -4,7 +4,7 @@ do_install_append_tcmode-external-sourcery () {
     install -d "${D}/environment-setup.d"
     cat >"${D}/environment-setup.d/external-codebench-toolchains.sh" <<END
 sourceryver="${SOURCERY_VERSION}"
-dirsuffix="$(echo "$sourceryver" | cut -d. -f1-2)"
+dirsuffix="\$(echo "\$sourceryver" | cut -d. -f1-2)"
 sys="${EXTERNAL_TARGET_SYS}"
 sysroot="${SDK_ARCH}-oesdk-${SDK_OS}"
 toolchainsdir="${SDKPATH}/../../../toolchains"


### PR DESCRIPTION
JIRA: SB-16035

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
