### PR TITLE
[dunfell] glibc: only append pkgversion and bug report url for Sourcery

### DIFF
--- a/recipes-core/glibc/glibc_%.bbappend
+++ b/recipes-core/glibc/glibc_%.bbappend
@@ -25,5 +25,5 @@ def get_pkgversion(d):
 SOURCERY_NAME ?= "Sourcery CodeBench"
 PKGVERSION = "${@get_pkgversion(d) or '${SOURCERY_NAME} ${SOURCERY_VERSION}'}"
 
-EXTRA_OECONF_append = " --with-pkgversion="${PKGVERSION}""
-EXTRA_OECONF_append = " --with-bugurl=${BUG_REPORT_URL}"
+EXTRA_OECONF_append_tcmode-external-sourcery = " --with-pkgversion="${PKGVERSION}""
+EXTRA_OECONF_append_tcmode-external-sourcery = " --with-bugurl=${BUG_REPORT_URL}"


### PR DESCRIPTION
The do_configure step fails with

tmp/work/aarch64-mel-linux/glibc/2.31+gitAUTOINC+6fdf971c9d-r0/temp/run.do_configure.24059: Bad substitution
WARNING: exit code 2 from a shell command.

This happens because of an unexpanded PKGVERSION which fails
to find SOURCERY_VERSION that is only set with toolchain's
external mode. Even defining a default for this variable
would be wrong as external_run() returns UNKNOWN for tcmode
not starting with external so get_pkgversion() does not return
anything or more appropriately None in this case. For yocto
internal toolchain defining a default for SOURCERY_VERSION
would pass a wrong pkgversion (SOURCERY_NAME SOURCERY_VERSION)
on to configure due to this.
We now conditionalize the appending of pkgverion and bug report
url so it is only done for external sourcery tools.

Fixes: https://jira.alm.mentorg.com/browse/SB-16695
Signed-off-by: Awais Belal <awais_belal@mentor.com>