### PR TITLE
[RFC] glibc-sourcery: Add hash to glibc PKGVERSION

### DIFF
--- a/recipes-sourcery/glibc-sourcery/glibc-pkgversion.inc
+++ b/recipes-sourcery/glibc-sourcery/glibc-pkgversion.inc
@@ -1,0 +1,42 @@
+def glibc_pkgversion (d):
+    src = d.getVar('S')
+    if src == None:
+        return 'INVALID'
+
+    # Exclude some files from calculation of hash:
+    # '.git' leads to unpredictable results,
+    # '.pc' and 'patches' do not contain sources,
+    # 'elf/ldd.bash.in' is modified in do_configure_prepend.
+    skip = ['.git', '.pc', 'patches', os.path.join('elf', 'ldd.bash.in')]
+
+    def parse_dir(root, d, h):
+        ls = sorted(os.listdir(d)) # sort directory entries to ensure reproducibility
+        for f in ls:
+            p = os.path.join(d, f) # absolute path
+            r = os.path.relpath(p, root) # relative path
+            if r in skip:
+                return
+            if os.path.islink(p):
+                pass # skip symbolic links
+            elif os.path.isdir(p):
+                parse_dir(root, p, h) # recursively run this sub-routine
+            elif os.path.isfile(p):
+                # Hash all file contents
+                with open(p, 'rb') as fd:
+                    h.update((r + ' ').encode('utf-8')) # add relative file path
+                    h.update(fd.read()) # add file contents
+                    h.update(b'!@#$%^&*') # add file separator
+
+    if os.path.isdir(src):
+        import hashlib
+
+        # SHA256 should be a good choice
+        h = hashlib.sha256()
+
+        # Concatenate all files
+        parse_dir(src, src, h)
+
+        # Calculate hash
+        return h.hexdigest()
+
+EXTRA_OECONF_append = " --with-pkgversion='built with hash ${@glibc_pkgversion(d)}'"

--- a/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
+++ b/recipes-sourcery/glibc-sourcery/glibc-sourcery.bb
@@ -1,5 +1,6 @@
 require recipes-core/glibc/glibc.inc
 require recipes-external/glibc/glibc-external-version.inc
+include glibc-pkgversion.inc
 
 FILESPATH .= ":${COREBASE}/meta/recipes-core/glibc/glibc"
 EXTERNAL_TOOLCHAIN_SYSROOT ?= "${@external_run(d, 'gcc', *(TARGET_CC_ARCH.split() + ['-print-sysroot'])).rstrip()}"


### PR DESCRIPTION
CUSTOMER ISSUE ID: TBD
MGC ISSUE ID: ADIT-75
SUMMARY: glibc: Add versioning
DESCRIPTION: glibc: Add versioning

RESOLUTION:
We can calculate a hash value for the glibc sources and use it as
an argument for --with-pkgversion to sign our builds. That will allow us
to identify glibc binaries via the output of 'ldd --version'.

DEPENDENCIES: None
LICENSE: MIT
TEST SUMMARY: Build and sanity.
KNOWN LIMITATIONS: None
SOURCES: None