### PR TITLE
Fix header conflicts between glibc and linux-libc-headers

### DIFF
--- a/recipes-external/glibc/glibc-external.bbappend
+++ b/recipes-external/glibc/glibc-external.bbappend
@@ -3,7 +3,12 @@ PROVIDES:remove:tcmode-external-sourcery = "\
     linux-libc-headers \
     linux-libc-headers-dev\
 "
+LINUX_LIBC_RDEP_REMOVE:tcmode-external-sourcery = ""
 
 FILES:${PN}-dev:remove:tcmode-external-sourcery = "${@' '.join('${includedir}/%s' % d for d in '${linux_include_subdirs}'.split())}"
 
-LINUX_LIBC_RDEP_REMOVE:tcmode-external-sourcery = ""
+remove_sys () {
+    rm -rf "${D}${includedir}/sys"
+}
+
+do_install[postfuncs] += "remove_sys"

--- a/recipes-external/linux-libc-headers/linux-libc-headers-external.bb
+++ b/recipes-external/linux-libc-headers/linux-libc-headers-external.bb
@@ -7,8 +7,14 @@ LIC_FILES_CHKSUM = "${COMMON_LIC_CHKSUM}"
 DEPENDS = ""
 SRC_URI = ""
 
-linux_include_subdirs = "asm asm-generic bits drm linux mtd rdma sound sys video"
+linux_include_subdirs = "asm asm-generic bits drm linux mtd rdma sound video"
 FILES:${PN}-dev = "${@' '.join('${includedir}/%s' % d for d in '${linux_include_subdirs}'.split())}"
+
+libc_headers_file = "${@bb.utils.which('${BBPATH}', 'recipes-external/glibc/glibc-external/libc.headers')}"
+FILES:${PN}-dev += "\
+    ${@' '.join('${includedir}/' + f.rstrip() for f in oe.utils.read_file('${libc_headers_file}').splitlines() if f.startswith('sys/'))} \
+"
+FILES:${PN}-dev[file-checksums] += "${libc_headers_file}:True"
 
 BBCLASSEXTEND = ""
 


### PR DESCRIPTION
JIRA: SB-20035

These fixes are needed to use the meta-sourcery `TCMODE` with a Yocto 4.0 based CodeBench toolchain.