### PR TITLE
Ship the external toolchain in the Yocto SDK

### DIFF
--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -1,5 +1,15 @@
 require conf/distro/include/tcmode-external-oe-sdk.inc
 
+def codebench_toolchain_dirname(d):
+    external, toolchains = d.getVar('EXTERNAL_TOOLCHAIN'), d.getVar('TOOLCHAINS_PATH')
+    if external and toolchains and oe.path.is_path_parent(toolchains, external):
+        return os.path.relpath(external, toolchains)
+
+EXTERNAL_TOOLCHAINS_DIR = "${@codebench_toolchain_dirname(d) or d.getVar('EXTERNAL_TARGET_SYS')}"
+EXTERNAL_TOOLCHAINS_DIR[vardepvalue] = "${EXTERNAL_TOOLCHAINS_DIR}"
+
+SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchains/${EXTERNAL_TOOLCHAINS_DIR}"
+
 TCMODEOVERRIDES .= ":tcmode-external-sourcery"
 
 # This is defined in default-providers.inc, which is parsed before the tcmode,

--- a/core/recipes-core/meta/meta-environment.bbappend
+++ b/core/recipes-core/meta/meta-environment.bbappend
@@ -1,27 +1,16 @@
 # CodeBench needs TARGET_PREFIX to align with the external toolchain
 TARGET_PREFIX:tcmode-external-sourcery = "${EXTERNAL_TARGET_SYS}-"
 
-def get_toolchain_bindir(d):
-    from pathlib import Path
-
-    external = d.getVar('EXTERNAL_TOOLCHAIN')
-    bin = d.getVar('EXTERNAL_TOOLCHAIN_BIN')
-    if external and bin:
-        external = Path(external)
-        bin = Path(bin)
-        if external.parent.name == 'toolchains':
-            return Path(external.name) / bin.relative_to(external)
-    return 'UNKNOWN'
+SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchain"
+EXTERNAL_TOOLCHAIN_RELBIN = "${@os.path.relpath(d.getVar('EXTERNAL_TOOLCHAIN_BIN'), d.getVar('EXTERNAL_TOOLCHAIN'))}"
+TOOLCHAIN_PATH:tcmode-external-sourcery = "${SDKPATHTOOLCHAIN}/${EXTERNAL_TOOLCHAIN_RELBIN}"
 
 create_sdk_files:append:tcmode-external-sourcery () {
     script=${SDK_OUTPUT}/${SDKPATH}/environment-setup-${REAL_MULTIMACH_TARGET_SYS}
     cat >>"$script" <<END
-toolchainsdir="${SDKPATH}/../../../toolchains"
-bindir="\$toolchainsdir/${@get_toolchain_bindir(d)}"
-if [ -e "\$bindir" ]; then
-    PATH="\$PATH:\$bindir"
-else
-    echo >&2 "Warning: failed to add \$bindir to the path: No such file or directory"
+TOOLCHAIN_PATH=${TOOLCHAIN_PATH}
+if [ -e "\$TOOLCHAIN_PATH" ]; then
+    PATH="\$PATH:\$TOOLCHAIN_PATH"
 fi
 END
 }

--- a/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
+++ b/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
@@ -1,0 +1,9 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Include the external toolchain in our Yocto SDKs, not the internal one, by default
+BINUTILS:tcmode-external-sourcery ?= ""
+GCC:tcmode-external-sourcery ?= ""
+GDB:tcmode-external-sourcery ?= ""
+RDEPENDS:${PN}:append:tcmode-external-sourcery = " external-toolchain-${TRANSLATED_TARGET_ARCH}"

--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -1,0 +1,30 @@
+SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchain"
+
+inherit cross-canadian
+
+# FIXME: Set to the union of all included component licenses. Ideally this would
+# adapt to the components utilized. Alternatively, package up each component of
+# the toolchain separately.
+LICENSE = "CLOSED"
+
+PN .= "-${TRANSLATED_TARGET_ARCH}"
+SKIPPED = "1"
+SKIPPED:tcmode-external = "0"
+
+python () {
+    external = d.getVar("EXTERNAL_TOOLCHAIN")
+    if not external or not os.path.isdir(external) or d.getVar("SKIPPED") == "1":
+        raise bb.parse.SkipRecipe("An existing external toolchain at EXTERNAL_TOOLCHAIN is required and TCMODE must be set appropriately")
+}
+
+deltask do_configure
+deltask do_compile
+
+do_install () {
+    bbnote "Copying ${EXTERNAL_TOOLCHAIN}/. to ${D}/${SDKPATHTOOLCHAIN}/"
+    install -d ${D}/$(dirname ${SDKPATHTOOLCHAIN})
+    cp -a "${EXTERNAL_TOOLCHAIN}/." "${D}/${SDKPATHTOOLCHAIN}/"
+}
+
+FILES:${PN} += "${SDKPATHTOOLCHAIN}"
+INSANE_SKIP:${PN} += "already-stripped"


### PR DESCRIPTION
JIRA: SB-19962

This has one major remaining issue to address in the future, and one area worth investigation:

- `LICENSE` isn't correct in `external-toolchain`, but we want this to match the contents of the packaged external toolchain, so we need that information to be available in the CodeBench toolchain and pull it from there. We could potentially package and include -lic packages in the sysroots, or we could add common license files for all licenses in question to the legal directory, etc.
- We should consider attempting to construct the Yocto SDK on top of the existing CodeBench toolchain Yocto SDK, rather than embedding one in the other.