### PR TITLE
external-toolchain: skip strip and debug split

### DIFF
--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -10,6 +10,9 @@ LICENSE = "CLOSED"
 PN .= "-${TRANSLATED_TARGET_ARCH}"
 SKIPPED = "1"
 SKIPPED:tcmode-external = "0"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
 
 python () {
     external = d.getVar("EXTERNAL_TOOLCHAIN")
@@ -27,4 +30,3 @@ do_install () {
 }
 
 FILES:${PN} += "${SDKPATHTOOLCHAIN}"
-INSANE_SKIP:${PN} += "already-stripped"


### PR DESCRIPTION
This stuff has already been built and processed, there's no point doing
it ourselves, and can result in build failures due to missing objcopy.