### PR TITLE
Re-relocate a distributed toolchain when relocating our SDK

### DIFF
--- a/classes/sdk-relocate-toolchain.bbclass
+++ b/classes/sdk-relocate-toolchain.bbclass
@@ -1,0 +1,8 @@
+SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchain"
+
+SDK_POST_INSTALL_COMMAND:append() {
+toolchain_rel_script="$target_sdk_dir/${@os.path.relpath(d.getVar('SDKPATHTOOLCHAIN'), d.getVar('SDKPATH'))}/relocate_sdk.sh"
+if [ -e "$toolchain_rel_script" ]; then
+    $SUDO_EXEC "$toolchain_rel_script"
+fi
+}

--- a/conf/distro/include/tcmode-external-sourcery.inc
+++ b/conf/distro/include/tcmode-external-sourcery.inc
@@ -1,5 +1,10 @@
 require conf/distro/include/tcmode-external-oe-sdk.inc
 
+# Also relocate the included external toolchain
+SDK_CLASSES ??= ""
+SDK_CLASSES:append = " sdk-relocate-toolchain"
+IMAGE_CLASSES:append = " ${SDK_CLASSES}"
+
 def codebench_toolchain_dirname(d):
     external, toolchains = d.getVar('EXTERNAL_TOOLCHAIN'), d.getVar('TOOLCHAINS_PATH')
     if external and toolchains and oe.path.is_path_parent(toolchains, external):


### PR DESCRIPTION
As we're redistributing the toolchain in our SDK, rather than building upon it, we're nesting Yocto SDKs. We need to ensure that both of them are relocated to the correct install path after installation.

JIRA: SB-20930