### PR TITLE
sdk-relocate-toolchain.bbclass: add a preceding newline to be safe

### DIFF
--- a/classes/sdk-relocate-toolchain.bbclass
+++ b/classes/sdk-relocate-toolchain.bbclass
@@ -1,6 +1,7 @@
 SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchain"
 
 SDK_POST_INSTALL_COMMAND:append() {
+
 toolchain_rel_script="$target_sdk_dir/${@os.path.relpath(d.getVar('SDKPATHTOOLCHAIN'), d.getVar('SDKPATH'))}/relocate_sdk.sh"
 if [ -e "$toolchain_rel_script" ]; then
     $SUDO_EXEC "$toolchain_rel_script"


### PR DESCRIPTION
Rather than relying on toolchain-shar-relocate.sh having a trailing
newline to separate the content, ensure we have one here for safety.

With the current behavior, if toolchain-shar-relocate.sh lacks a trailing
newline at the end of the file, this will be directly concatenated to that, so
the first line of this function and the last of that file will be merged to a
single line, resulting in failures.

JIRA: SB-21318