### PR TITLE
external-toolchain: pull in the ReadMe_OSS.html file when present 

### DIFF
--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -2,10 +2,10 @@ SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchain"
 
 inherit cross-canadian
 
-# FIXME: Set to the union of all included component licenses. Ideally this would
-# adapt to the components utilized. Alternatively, package up each component of
-# the toolchain separately.
-LICENSE = "CLOSED"
+# This license is simply an identifier to refer to the union of all the licenses of all
+# the included components of the external toolchain, as described in the included
+# ReadMe_OSS.html file.
+LICENSE = "Sourcery-Toolchain"
 
 PN .= "-${TRANSLATED_TARGET_ARCH}"
 SKIPPED = "1"

--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -2,6 +2,13 @@ SDKPATHTOOLCHAIN ?= "${SDKPATH}/toolchain"
 
 inherit cross-canadian
 
+LICENSE_FILE = "${EXTERNAL_TOOLCHAIN}/legal/ReadMe_OSS.html"
+# The ReadMe is included as a source file, not directly copied from
+# EXTERNAL_TOOLCHAIN in do_populate_lic, to ensure that it is also included in any
+# source archival methods, such as archiver.
+SRC_URI = "file://${LICENSE_FILE}"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/ReadMe_OSS.html"
+
 # This license is simply an identifier to refer to the union of all the licenses of all
 # the included components of the external toolchain, as described in the included
 # ReadMe_OSS.html file.
@@ -18,6 +25,14 @@ python () {
     external = d.getVar("EXTERNAL_TOOLCHAIN")
     if not external or not os.path.isdir(external) or d.getVar("SKIPPED") == "1":
         raise bb.parse.SkipRecipe("An existing external toolchain at EXTERNAL_TOOLCHAIN is required and TCMODE must be set appropriately")
+}
+
+do_unpack[postfuncs] += "move_readme"
+
+move_readme () {
+    if [ -n "${SRC_URI}" ]; then
+        mv "${WORKDIR}/${@d.getVar('LICENSE_FILE')[1:]}" "${WORKDIR}/ReadMe_OSS.html"
+    fi
 }
 
 deltask do_configure

--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -25,6 +25,12 @@ python () {
     external = d.getVar("EXTERNAL_TOOLCHAIN")
     if not external or not os.path.isdir(external) or d.getVar("SKIPPED") == "1":
         raise bb.parse.SkipRecipe("An existing external toolchain at EXTERNAL_TOOLCHAIN is required and TCMODE must be set appropriately")
+
+    # Allow for the readme to be optional, as it's not present in all toolchain versions
+    license_file = d.getVar("LICENSE_FILE")
+    if not os.path.exists(license_file):
+        d.setVar("SRC_URI", "")
+        d.setVar("LIC_FILES_CHKSUM", "")
 }
 
 do_unpack[postfuncs] += "move_readme"

--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -29,4 +29,6 @@ do_install () {
     cp -a "${EXTERNAL_TOOLCHAIN}/." "${D}/${SDKPATHTOOLCHAIN}/"
 }
 
+do_package_qa[noexec] = "1"
+
 FILES:${PN} += "${SDKPATHTOOLCHAIN}"

--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -50,6 +50,9 @@ do_install () {
     cp -a "${EXTERNAL_TOOLCHAIN}/." "${D}/${SDKPATHTOOLCHAIN}/"
 }
 
+ERROR_QA:remove = "license-checksum"
+WARN_QA:remove = "license-checksum"
+
 LICENSE_PATH += "${WORKDIR}/licenses"
 
 link_license () {

--- a/recipes-external/external-toolchain/external-toolchain.bb
+++ b/recipes-external/external-toolchain/external-toolchain.bb
@@ -50,6 +50,20 @@ do_install () {
     cp -a "${EXTERNAL_TOOLCHAIN}/." "${D}/${SDKPATHTOOLCHAIN}/"
 }
 
+LICENSE_PATH += "${WORKDIR}/licenses"
+
+link_license () {
+    if ! [ -e "${LICENSE_FILE}" ]; then
+        bbwarn "No license file present at ${LICENSE_FILE}, skipping"
+    else
+        ln -s "${WORKDIR}/ReadMe_OSS.html" "${WORKDIR}/licenses/${LICENSE}"
+    fi
+}
+link_license[dirs] += "${WORKDIR}/licenses"
+link_license[cleandirs] += "${WORKDIR}/licenses"
+
+do_populate_lic[prefuncs] += "link_license"
+
 do_package_qa[noexec] = "1"
 
 FILES:${PN} += "${SDKPATHTOOLCHAIN}"


### PR DESCRIPTION
- Add the readme in SRC_URI to ensure it gets picked up by any source
  archival methods, such as archiver.
- Add the readme as a license file to be included by tasks such as
  do_populate_lic, which ensures it is present in tmp/deploy/licenses.

JIRA: SB-20379, SB-20380

With this, we see the following in tmp/deploy/licenses when building an image or the recipe directly:
```console
$ ls tmp/deploy/licenses/external-toolchain-aarch64
generic_Sourcery-Toolchain  ReadMe_OSS.html  recipeinfo
```

And with archiver enabled with `ARCHIVER_MODE[src]="original"` and `COPYLEFT_LICENSE_INCLUDE="*"`:
```console
$ ls tmp/deploy/sources/aarch64-oe-linux/external-toolchain-aarch64-1.0-r0
ReadMe_OSS.html
```