### PR TITLE
packagegroup-cross-canadian: install toolchains for all multilibs

### DIFF
--- a/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
+++ b/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
@@ -6,4 +6,7 @@
 BINUTILS:tcmode-external-sourcery ?= ""
 GCC:tcmode-external-sourcery ?= ""
 GDB:tcmode-external-sourcery ?= ""
-RDEPENDS:${PN}:append:tcmode-external-sourcery = " external-toolchain-${TRANSLATED_TARGET_ARCH}"
+
+# Use indirection to stop this being expanded prematurely
+TOOLCHAIN_PACKAGE ?= "external-toolchain-${TRANSLATED_TARGET_ARCH}"
+RDEPENDS:${PN}:append:tcmode-external-sourcery = " ${@all_multilib_tune_values(d, 'TOOLCHAIN_PACKAGE')}"


### PR DESCRIPTION
As the external toolchain is a cross-canadian recipe just like
gcc/binutils/gdb, we need to duplicate the logic used for the latter
with the former, to ensure that all toolchains needed for all multilib
configurations are also redistributed with the SDK.

JIRA: SB-22039, SB-22040