### PR TITLE
Revert "layer.conf: set LAYERSERIES_COMPAT to mickledore"

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILE_PRIORITY_sourcery = "2"
 BBFILE_PATTERN_sourcery = "^${LAYERDIR}/"
 
 LAYERDEPENDS_sourcery = "core external-toolchain"
-LAYERSERIES_COMPAT_sourcery = "mickledore"
+LAYERSERIES_COMPAT_sourcery = "kirkstone"
 
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.%s' % (layer, ext) \
                for layer in '${BBFILE_COLLECTIONS}'.split() for ext in ['bb', 'bbappend'])}"


### PR DESCRIPTION
Our current development is kirkstone based, not mickledore or later.